### PR TITLE
Fix `DOCKER_ORG` in `build.sh`

### DIFF
--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export DOCKER_ORG=${DOCKER_ORG:-strimzi-examples}
+export DOCKER_ORG=${DOCKER_ORG:-strimzi-test-clients}
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
 export DOCKER_TAG=$COMMIT
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR fixes default `DOCKER_ORG` in `build.sh`, which should point to the `strimzi-test-clients`.