### PR TITLE
Add k8s config provider to all other Kafka clients

### DIFF
--- a/kafka/admin/src/main/java/AdminConfiguration.java
+++ b/kafka/admin/src/main/java/AdminConfiguration.java
@@ -58,8 +58,10 @@ public class AdminConfiguration {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
 
-        props.put("config.providers", "secrets");
+        // Kubernetes Config Provider
+        props.put("config.providers", "secrets,configmaps");
         props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        props.put("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider");
 
         if (config.getSslTruststoreCertificates() != null)   {
             log.info("Configuring truststore");

--- a/kafka/consumer/pom.xml
+++ b/kafka/consumer/pom.xml
@@ -43,6 +43,11 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-kubernetes-config-provider</artifactId>
+            <version>${kafka-kubernetes-config-provider.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kafka/consumer/src/main/java/ConsumerConfiguration.java
+++ b/kafka/consumer/src/main/java/ConsumerConfiguration.java
@@ -56,6 +56,12 @@ public class ConsumerConfiguration {
     @SuppressWarnings("BooleanExpressionComplexity")
     public static Properties createProperties(ConsumerConfiguration config) {
         Properties props = new Properties();
+
+        // Kubernetes Config Provider
+        props.put("config.providers", "secrets,configmaps");
+        props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        props.put("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider");
+
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, config.getGroupId());
         if (config.getClientRack() != null) {

--- a/kafka/producer/pom.xml
+++ b/kafka/producer/pom.xml
@@ -43,6 +43,11 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-kubernetes-config-provider</artifactId>
+            <version>${kafka-kubernetes-config-provider.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kafka/producer/src/main/java/ProducerConfiguration.java
+++ b/kafka/producer/src/main/java/ProducerConfiguration.java
@@ -58,6 +58,12 @@ public class ProducerConfiguration {
     @SuppressWarnings("BooleanExpressionComplexity")
     public static Properties createProperties(ProducerConfiguration config) {
         Properties props = new Properties();
+
+        // Kubernetes Config Provider
+        props.put("config.providers", "secrets,configmaps");
+        props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        props.put("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider");
+
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
         props.put(ProducerConfig.ACKS_CONFIG, config.getAcks());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");

--- a/kafka/streams/pom.xml
+++ b/kafka/streams/pom.xml
@@ -43,6 +43,11 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-oauth-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>kafka-kubernetes-config-provider</artifactId>
+            <version>${kafka-kubernetes-config-provider.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kafka/streams/src/main/java/StreamsConfiguration.java
+++ b/kafka/streams/src/main/java/StreamsConfiguration.java
@@ -55,6 +55,11 @@ public class StreamsConfiguration {
     public static Properties createProperties(StreamsConfiguration config) {
         Properties props = new Properties();
 
+        // Use Kafka config provider
+        props.put("config.providers", "secrets,configmaps");
+        props.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        props.put("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider");
+
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, config.getApplicationId());
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
         props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, config.getCommitInterval());


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR adds k8s config provider to all other Kafka clients - to producer, consumer and streams.