### PR TITLE
Fix docker tag when building images

### DIFF
--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -4,10 +4,17 @@ set -e
 
 export DOCKER_ORG=${DOCKER_ORG:-strimzi-test-clients}
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
-export DOCKER_TAG=$COMMIT
 
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
+
+if [ "$BRANCH" == "refs/heads/main" ]; then
+  export DOCKER_TAG="latest"
+elif [[ "$BRANCH" == "refs/tags/"* ]]; then
+  export DOCKER_TAG="${BRANCH#refs/tags/}"
+else
+  export DOCKER_TAG=$COMMIT
+fi
 
 ./docker-images/build-images.sh build
 
@@ -16,11 +23,6 @@ if [ "$BUILD_REASON" == "PullRequest" ] ; then
 elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/main" ]; then
   echo "Not in main branch or in release tag - nothing to push"
 else
-  if [ "$BRANCH" == "refs/heads/main" ]; then
-      export DOCKER_TAG="latest"
-  else
-      export DOCKER_TAG="${BRANCH#refs/tags/}"
-  fi
   echo "In main branch or in release tag - pushing images"
   docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

In #9 building of all images was correct, but we built it with wrong tag -> the images were built with `$COMMIT` tag, but when we wanted to re-tag it (for example to `latest`), the check failed because image with new `DOCKER_TAG` didn't exist. This PR fixes this issue.