### PR TITLE
Prepare `test-clients` repository for the first release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,31 @@
 RELEASE_VERSION ?= latest
 
+include ./Makefile.os
+
 SUBDIRS=kafka/consumer kafka/producer kafka/streams kafka/admin http/http-consumer http/http-producer
 DOCKER_TARGETS=docker_build docker_push docker_tag
 
 all: $(SUBDIRS)
 build: $(SUBDIRS)
 clean: $(SUBDIRS)
+release: release_examples release_maven
+
 $(DOCKER_TARGETS): $(SUBDIRS)
 
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+next_version:
+	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)
+	mvn versions:commit
+
+release_examples:
+	echo "Changing images in examples to: $(RELEASE_VERSION)"
+	$(FIND) ./examples -name '*.yaml' -type f -exec $(SED) -i '/image: "\?quay.io\/strimzi-test-clients\/[a-zA-Z0-9_.-]\?\+:[a-zA-Z0-9_.-]\+-kafka-[0-9.]\+"\?/s/:[a-zA-Z0-9_.-]\+-kafka-\([0-9.]\+\)/:$(RELEASE_VERSION)-kafka-\1/g' {} \;
+
+release_maven:
+	echo "Update pom versions to: $(RELEASE_VERSION)"
+	mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)
+	mvn versions:commit
 
 .PHONY: all $(SUBDIRS) $(DOCKER_TARGETS)

--- a/Makefile.os
+++ b/Makefile.os
@@ -1,0 +1,9 @@
+FIND = find
+SED = sed
+
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	FIND = gfind
+	SED = gsed
+endif

--- a/examples/http/http-consumer.yaml
+++ b/examples/http/http-consumer.yaml
@@ -34,7 +34,7 @@ spec:
               value: "100"
             - name: LOG_LEVEL
               value: DEBUG
-          image: quay.io/strimzi-test-clients/test-client-http-consumer:latest
+          image: quay.io/strimzi-test-clients/test-client-http-consumer:latest-kafka-3.0.0
           imagePullPolicy: IfNotPresent
           name: http-consumer
       restartPolicy: "Never"

--- a/examples/http/http-producer.yaml
+++ b/examples/http/http-producer.yaml
@@ -32,7 +32,7 @@ spec:
               value: "100"
             - name: LOG_LEVEL
               value: DEBUG
-          image: quay.io/strimzi-test-clients/test-client-http-producer:latest
+          image: quay.io/strimzi-test-clients/test-client-http-producer:latest-kafka-3.0.0
           imagePullPolicy: IfNotPresent
           name: http-producer
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/alter-topics.yaml
+++ b/examples/kafka/admin-client/alter-topics.yaml
@@ -32,7 +32,7 @@ spec:
           value: "100"
         - name: LOG_LEVEL
           value: DEBUG
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: alter-admin-client
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/create-topics.yaml
+++ b/examples/kafka/admin-client/create-topics.yaml
@@ -34,7 +34,7 @@ spec:
           value: "100"
         - name: LOG_LEVEL
           value: DEBUG
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: create-admin-client
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/delete-topics.yaml
+++ b/examples/kafka/admin-client/delete-topics.yaml
@@ -30,7 +30,7 @@ spec:
           value: "100"
         - name: LOG_LEVEL
           value: DEBUG
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: delete-admin-client-1
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/delete-with-offset-scram512.yaml
+++ b/examples/kafka/admin-client/delete-with-offset-scram512.yaml
@@ -37,7 +37,7 @@ spec:
             sasl.mechanism=SCRAM-SHA-512
             security.protocol=SASL_PLAINTEXT
             sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="test-user" password="myPassword";
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: delete-admin-client-offset-scram
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/delete-with-offset.yaml
+++ b/examples/kafka/admin-client/delete-with-offset.yaml
@@ -32,7 +32,7 @@ spec:
           value: "200"
         - name: LOG_LEVEL
           value: DEBUG
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: delete-admin-client-with-offset
       restartPolicy: "Never"

--- a/examples/kafka/admin-client/list-topics.yaml
+++ b/examples/kafka/admin-client/list-topics.yaml
@@ -26,7 +26,7 @@ spec:
           value: list
         - name: LOG_LEVEL
           value: DEBUG
-        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest
+        image: quay.io/strimzi-test-clients/test-client-kafka-admin:latest-kafka-3.0.0
         imagePullPolicy: IfNotPresent
         name: list-admin-client
       restartPolicy: "Never"

--- a/examples/kafka/kafka-consumer.yaml
+++ b/examples/kafka/kafka-consumer.yaml
@@ -30,7 +30,7 @@ spec:
               value: my-group
             - name: LOG_LEVEL
               value: DEBUG
-          image: quay.io/strimzi-test-clients/test-client-kafka-consumer:latest
+          image: quay.io/strimzi-test-clients/test-client-kafka-consumer:latest-kafka-3.0.0
           imagePullPolicy: IfNotPresent
           name: kafka-consumer-client
       restartPolicy: "Never"

--- a/examples/kafka/kafka-producer.yaml
+++ b/examples/kafka/kafka-producer.yaml
@@ -34,7 +34,7 @@ spec:
               value: all
             - name: LOG_LEVEL
               value: DEBUG
-          image: quay.io/strimzi-test-clients/test-client-kafka-producer:latest
+          image: quay.io/strimzi-test-clients/test-client-kafka-producer:latest-kafka-3.0.0
           imagePullPolicy: IfNotPresent
           name: kafka-producer-client
       restartPolicy: "Never"

--- a/examples/kafka/kafka-streams.yaml
+++ b/examples/kafka/kafka-streams.yaml
@@ -28,7 +28,7 @@ spec:
               value: my-topic
             - name: TARGET_TOPIC
               value: my-topic-reversed
-          image: quay.io/strimzi-test-clients/test-client-kafka-streams:latest
+          image: quay.io/strimzi-test-clients/test-client-kafka-streams:latest-kafka-3.0.0
           imagePullPolicy: IfNotPresent
           name: kafka-streams-client
       restartPolicy: "Never"


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR adds more goals to `Makefile` for release process:
- `release_examples` - changes images in all `yaml`s inside the `examples` folder
- `release_version` - changes project `version` to `RELEASE_VERSION` in `pom`s of all modules
- `next_version` -  changes project `version` to `NEXT_VERSION` in `pom`s of all modules

Also changes `image`s inside all example `yaml`s to correct one after #9 