### PR TITLE
Add s390x support to Azure CI and images

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -43,6 +43,7 @@ jobs:
         parameters:
           JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
+      - template: 'templates/setup_docker.yaml'
       - bash: ".azure/scripts/build.sh"
         env:
           BUILD_REASON: $(Build.Reason)

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -51,6 +51,7 @@ jobs:
           COMMIT: $(Build.SourceVersion)
           DOCKER_USER: $(DOCKER_USER)
           DOCKER_PASS: $(DOCKER_PASS)
+          ARCHS: 'amd64 s390x'
         displayName: "Build and test"
       - task: PublishTestResults@2
         inputs:

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -26,5 +26,6 @@ else
   echo "In main branch or in release tag - pushing images"
   docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 
+  docker buildx create --use
   ./docker-images/build-images.sh
 fi

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -16,7 +16,7 @@ else
   export DOCKER_TAG=$COMMIT
 fi
 
-./docker-images/build-images.sh build
+./docker-images/build-images.sh "$ARCHS" build
 
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
   echo "Building Pull Request - nothing to push"
@@ -26,6 +26,5 @@ else
   echo "In main branch or in release tag - pushing images"
   docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 
-  docker buildx create --use
-  ./docker-images/build-images.sh
+  ./docker-images/build-images.sh "$ARCHS"
 fi

--- a/.azure/templates/setup_docker.yaml
+++ b/.azure/templates/setup_docker.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: DockerInstaller@0
+    displayName: Install Docker
+    inputs:
+      dockerVersion: 20.10.8
+      releaseType: stable
+  - bash: |
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    displayName: 'Register QEMU binary'

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -12,7 +12,11 @@ DOCKER_REGISTRY    ?= quay.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
 DOCKER_VERSION_ARG ?= latest
-PLATFORMS          ?= linux/amd64,linux/s390x
+
+ifdef DOCKER_ARCHITECTURE
+  DOCKER_PLATFORM = --platform linux/$(DOCKER_ARCHITECTURE)
+  DOCKER_PLATFORM_TAG_SUFFIX = -$(DOCKER_ARCHITECTURE)
+endif
 
 all: docker_build docker_push
 
@@ -20,16 +24,28 @@ docker_build:
 	echo "Building Docker image ..."
 	mkdir -p scripts
 	cp ../../scripts/run.sh ./scripts/run.sh
-	docker build --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKERFILE_DIR)
+	docker $(DOCKER_BUILDX) build $(DOCKER_PLATFORM) --build-arg version=$(DOCKER_VERSION_ARG) -t strimzi/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) $(DOCKERFILE_DIR)
 	rm -rf ./scripts
 
 docker_tag:
-	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_TAG) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
-	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) ..."
+	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 
-docker_push:
-	echo "Building and pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
-	mkdir -p scripts
-	cp ../../scripts/run.sh ./scripts/run.sh
-	docker buildx build --push --platform=$(PLATFORMS) --build-arg version=$(DOCKER_VERSION_ARG) --tag $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKERFILE_DIR)
-	rm -rf ./scripts
+docker_push:docker_tag
+	echo "Pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) ..."
+	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_amend_manifest
+docker_amend_manifest:
+	# Create / Amend the manifest
+	docker manifest create $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --amend $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_push_manifest
+docker_push_manifest:
+	# Push the manifest to the registry
+	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+
+.PHONY: docker_delete_manifest
+docker_delete_manifest:
+	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
+	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -12,6 +12,7 @@ DOCKER_REGISTRY    ?= quay.io
 DOCKER_ORG         ?= $(USER)
 DOCKER_TAG         ?= latest
 DOCKER_VERSION_ARG ?= latest
+PLATFORMS          ?= linux/amd64,linux/s390x
 
 all: docker_build docker_push
 
@@ -26,6 +27,9 @@ docker_tag:
 	echo "Tagging strimzi/$(PROJECT_NAME):$(DOCKER_TAG) to $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
 	docker tag strimzi/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
 
-docker_push: docker_tag
-	echo "Pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
-	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+docker_push:
+	echo "Building and pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) ..."
+	mkdir -p scripts
+	cp ../../scripts/run.sh ./scripts/run.sh
+	docker buildx build --push --platform=$(PLATFORMS) --build-arg version=$(DOCKER_VERSION_ARG) --tag $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) $(DOCKERFILE_DIR)
+	rm -rf ./scripts

--- a/pom.xml
+++ b/pom.xml
@@ -18,15 +18,15 @@
         <maven.checkstyle.version>3.1.1</maven.checkstyle.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <slf4j-simple.version>1.6.2</slf4j-simple.version>
         <kafka.version>3.0.0</kafka.version>
         <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
         <jaeger.version>1.1.0</jaeger.version>
         <strimzi-oauth-callback.version>0.8.1</strimzi-oauth-callback.version>
-        <vertx-core.version>4.1.0</vertx-core.version>
-        <netty.version>4.1.66.Final</netty.version>
-        <jackson.version>2.12.4</jackson.version>
+        <vertx-core.version>4.2.3</vertx-core.version>
+        <netty.version>4.1.72.Final</netty.version>
+        <jackson.version>2.13.1</jackson.version>
         <maven-shade.version>3.2.1</maven-shade.version>
         <kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
     </properties>


### PR DESCRIPTION
This PR is to add s390x (multi-arch) support to Azure CI to build and push docker images.

The multi-arch test-clients images are built via QEMU and the generated s390x images have been verified on s390x VM.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>