### PR TITLE
Add `ppc64le` and `arm64` support

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -51,7 +51,7 @@ jobs:
           COMMIT: $(Build.SourceVersion)
           DOCKER_USER: $(DOCKER_USER)
           DOCKER_PASS: $(DOCKER_PASS)
-          ARCHS: 'amd64 s390x'
+          ARCHS: 'amd64 s390x ppc64le'
         displayName: "Build and test"
       - task: PublishTestResults@2
         inputs:

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -51,7 +51,7 @@ jobs:
           COMMIT: $(Build.SourceVersion)
           DOCKER_USER: $(DOCKER_USER)
           DOCKER_PASS: $(DOCKER_PASS)
-          ARCHS: 'amd64 s390x ppc64le'
+          ARCHS: 'amd64 s390x ppc64le arm64'
         displayName: "Build and test"
       - task: PublishTestResults@2
         inputs:


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR adds support for `ppc64le`and `arm64` to our images.