### PR TITLE
Add tracing module to main pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <modules>
         <module>kafka</module>
         <module>http</module>
+        <module>tracing</module>
     </modules>
 
     <properties>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -9,7 +9,9 @@
         <artifactId>test-clients</artifactId>
         <version>0.2.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>test-client-tracing</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

In #16 we forgot to add `tracing` module into the main pom file, this PR fixes this issue.