### PR TITLE
Remove packaging -> pom from tracing

### DIFF
--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>test-client-tracing</artifactId>
-    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

I wrongly added `<packaging>pom</packaging>` into the `tracing` module, which causes to not deliver the `jar`, which is needed as dependency for other modules. This PR fixes this accident.