### PR TITLE
Change version to `0.3.0-SNAPSHOT`

### DIFF
--- a/http/http-consumer/pom.xml
+++ b/http/http-consumer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>http-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-http-consumer</artifactId>
 

--- a/http/http-producer/pom.xml
+++ b/http/http-producer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>http-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-http-producer</artifactId>
 

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-test-clients</artifactId>

--- a/kafka/admin/pom.xml
+++ b/kafka/admin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>kafka-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-kafka-admin</artifactId>
 

--- a/kafka/consumer/pom.xml
+++ b/kafka/consumer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>kafka-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-kafka-consumer</artifactId>
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-test-clients</artifactId>

--- a/kafka/producer/pom.xml
+++ b/kafka/producer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>kafka-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-kafka-producer</artifactId>
 

--- a/kafka/streams/pom.xml
+++ b/kafka/streams/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>kafka-test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-client-kafka-streams</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.strimzi</groupId>
     <artifactId>test-clients</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
 
     <modules>
         <module>kafka</module>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.strimzi</groupId>
         <artifactId>test-clients</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-client-tracing</artifactId>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

Since `0.2.0` is released, we should update the main branch to point to `0.3.0-SNAPSHOT`