### PR TITLE
Remove cyclical reference for docker_user and docker_pass

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -35,8 +35,8 @@ jobs:
       BUILD_REASON: $(Build.Reason)
       BRANCH: $(Build.SourceBranch)
       COMMIT: $(Build.SourceVersion)
-      DOCKER_USER: $(DOCKER_USER)
-      DOCKER_PASS: $(DOCKER_PASS)
+      QUAY_USER: $(DOCKER_USER)
+      QUAY_PASS: $(DOCKER_PASS)
       DOCKER_REGISTRY: "quay.io"
       ARCHITECTURES: 'amd64 s390x ppc64le arm64'
     # Pipeline steps
@@ -56,7 +56,7 @@ jobs:
       - bash: "make docker_build"
         displayName: "Build containers"
       - script: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
+            docker login -u $QUAY_USER -p $QUAY_PASS $DOCKER_REGISTRY
             make docker_push docker_amend_manifest docker_push_manifest
         displayName: "Push containers"
         condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))


### PR DESCRIPTION
Container push is failing due to cyclical reference for DOCKER_USER and DOCKER_PASS:

```
##[warning]Unable to expand variable 'DOCKER_USER'. A cyclical reference was detected.
##[warning]Unable to expand variable 'DOCKER_PASS'. A cyclical reference was detected.
Starting: Push containers
Error: Cannot perform an interactive login from a non TTY device
```

This PR solves that.

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>