### PR TITLE
Use proper org for pushing images, build only for docker_build

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -56,12 +56,10 @@ jobs:
           DOCKER_ORG: "strimzi-test-clients"
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
-            docker login -u $QUAY_USER -p $QUAY_PASS $DOCKER_REGISTRY
+            docker login -u $(QUAY_USER) -p $(QUAY_PASS) $DOCKER_REGISTRY
             make docker_push docker_amend_manifest docker_push_manifest
         displayName: "Push containers"
         env:
-          QUAY_USER: $(DOCKER_USER)
-          QUAY_PASS: $(DOCKER_PASS)
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi-test-clients"
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -65,7 +65,7 @@ jobs:
           DOCKER_USER: $(QUAY_USER)
           DOCKER_PASS: $(QUAY_PASS)
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
-#        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -35,11 +35,6 @@ jobs:
       BUILD_REASON: $(Build.Reason)
       BRANCH: $(Build.SourceBranch)
       COMMIT: $(Build.SourceVersion)
-      QUAY_USER: $(DOCKER_USER)
-      QUAY_PASS: $(DOCKER_PASS)
-      DOCKER_REGISTRY: "quay.io"
-      DOCKER_ORG: "strimzi-test-clients"
-      ARCHITECTURES: 'amd64 s390x ppc64le arm64'
     # Pipeline steps
     steps:
       - task: Cache@2
@@ -56,21 +51,21 @@ jobs:
         displayName: "Build Java artifacts"
       - bash: "make docker_build"
         displayName: "Build containers"
-#        env:
-#          DOCKER_REGISTRY: "quay.io"
-#          DOCKER_ORG: "strimzi-test-clients"
-#          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
+        env:
+          DOCKER_REGISTRY: "quay.io"
+          DOCKER_ORG: "strimzi-test-clients"
+          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
-            docker login -u $(QUAY_USER) -p $(QUAY_PASS) $(DOCKER_REGISTRY)
+            docker login -u $QUAY_USER -p $QUAY_PASS $DOCKER_REGISTRY
             make docker_push docker_amend_manifest docker_push_manifest
         displayName: "Push containers"
-#        env:
-#          QUAY_USER: $(DOCKER_USER)
-#          QUAY_PASS: $(DOCKER_PASS)
-#          DOCKER_REGISTRY: "quay.io"
-#          DOCKER_ORG: "strimzi-test-clients"
-#          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
-#        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+        env:
+          QUAY_USER: $(DOCKER_USER)
+          QUAY_PASS: $(DOCKER_PASS)
+          DOCKER_REGISTRY: "quay.io"
+          DOCKER_ORG: "strimzi-test-clients"
+          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
+        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -38,6 +38,7 @@ jobs:
       QUAY_USER: $(DOCKER_USER)
       QUAY_PASS: $(DOCKER_PASS)
       DOCKER_REGISTRY: "quay.io"
+      DOCKER_ORG: "strimzi-test-clients"
       ARCHITECTURES: 'amd64 s390x ppc64le arm64'
     # Pipeline steps
     steps:
@@ -55,11 +56,21 @@ jobs:
         displayName: "Build Java artifacts"
       - bash: "make docker_build"
         displayName: "Build containers"
+#        env:
+#          DOCKER_REGISTRY: "quay.io"
+#          DOCKER_ORG: "strimzi-test-clients"
+#          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
-            docker login -u $QUAY_USER -p $QUAY_PASS $DOCKER_REGISTRY
+            docker login -u $(QUAY_USER) -p $(QUAY_PASS) $(DOCKER_REGISTRY)
             make docker_push docker_amend_manifest docker_push_manifest
         displayName: "Push containers"
-        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+#        env:
+#          QUAY_USER: $(DOCKER_USER)
+#          QUAY_PASS: $(DOCKER_PASS)
+#          DOCKER_REGISTRY: "quay.io"
+#          DOCKER_ORG: "strimzi-test-clients"
+#          ARCHITECTURES: 'amd64 s390x ppc64le arm64'
+#        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -56,12 +56,14 @@ jobs:
           DOCKER_ORG: "strimzi-test-clients"
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
-            docker login -u $(QUAY_USER) -p $(QUAY_PASS) $DOCKER_REGISTRY
+            docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
             make docker_push docker_amend_manifest docker_push_manifest
         displayName: "Push containers"
         env:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi-test-clients"
+          DOCKER_USER: $(QUAY_USER)
+          DOCKER_PASS: $(QUAY_PASS)
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
 #        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       - task: PublishTestResults@2

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -65,7 +65,7 @@ jobs:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi-test-clients"
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
-        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+#        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit

--- a/docker-images/build-images.sh
+++ b/docker-images/build-images.sh
@@ -11,13 +11,17 @@ DOCKER_TAG=${DOCKER_TAG:-"latest"}
 MVN_ARGS=${MVN_ARGS:-""}
 
 echo "Building Kafka clients with versions inside kafka.version file"
-echo "Used build mode: $MODE"
+echo "Used build mode: $TARGETS"
 
 for KAFKA_VERSION in $KAFKA_VERSIONS
 do
   for KAFKA_MODULE in $KAFKA_MODULES
   do
-    MVN_ARGS="$MVN_ARGS -Dkafka.version=$KAFKA_VERSION" make java_build --directory=$KAFKA_MODULE
+    # build only if docker_build is passed
+    if [[ "$TARGETS" =~ "docker_build" ]];
+    then
+      MVN_ARGS="$MVN_ARGS -Dkafka.version=$KAFKA_VERSION" make java_build --directory=$KAFKA_MODULE
+    fi
 
     for ARCH in $ARCHITECTURES
     do


### PR DESCRIPTION
This PR adds proper value for `DOCKER_ORG` which fixes the image builds. It also skips the build of java artifacts during tag. push, etc. At least it passes username and password for docker properly.

Signed-off-by: Jakub Stejskal <xstejs24@gmail.com>