### PR TITLE
Fix building images and pushing them for the tags

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -54,6 +54,8 @@ jobs:
         env:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi-test-clients"
+          ${{ if startsWith(variables['build.sourceBranch'], 'refs/tags/') }}:
+            DOCKER_TAG: ${{ replace(variables['build.SourceBranch'], 'refs/tags/', '') }}
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
@@ -64,8 +66,10 @@ jobs:
           DOCKER_ORG: "strimzi-test-clients"
           DOCKER_USER: $(QUAY_USER)
           DOCKER_PASS: $(QUAY_PASS)
+          ${{ if startsWith(variables['build.sourceBranch'], 'refs/tags/') }}:
+            DOCKER_TAG: ${{ replace(variables['build.SourceBranch'], 'refs/tags/', '') }}
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
-        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+        condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/tags/')))
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

It seems that when we are building images on tags, the images are just builded and not pushed into the registries.
That means when we are releasing new version of test-clients, the images are not existing after the official release.

This PR fixes this issue.