### PR TITLE
Deprecated `OpenTracing` and use OTLP exporter as a default exporter for OTel

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,12 +1,13 @@
 # Tracing
 
 Currently this `tracing` module supports two different tracing abstractions
- * OpenTracing
+ * OpenTracing (deprecated)
  * OpenTelemetry 
  
 where both use `Jaeger` as the actual tracing implementation.
 
-Actual tracing usage is triggered by specific `service name` env var usage.
+For specifying, which `tracing` type should be used, the `TRACING_TYPE` environment variable has to be specified.
+The value corresponds to abstraction names - `OpenTracing` or `OpenTelemetry`.
 
 List of env vars we need to set:
 
@@ -17,4 +18,7 @@ List of env vars we need to set:
 #### OpenTelemetry
  * OTEL_SERVICE_NAME -- this triggers OpenTelemetry tracing
  * OTEL_EXPORTER_JAEGER_ENDPOINT -- url where the Jaeger traces are sent
- * OTEL_TRACES_EXPORTER=jaeger (this is not required, as it's done by the run.sh script)
+ * OTEL_TRACES_EXPORTER=otlp (this is not required, as it's done by the code)
+    * for different exporter the `/tracing/pom.xml` has to be edited and you'll have to build new, custom images
+    * example of changing `OTLP` exporter to `Jaeger`
+      * `<artifactId>opentelemetry-exporter-otlp</artifactId>` -> `<artifactId>opentelemetry-exporter-jaeger</artifactId>`

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
@@ -42,7 +42,7 @@ public class OpenTelemetryHandle implements TracingHandle {
             System.setProperty(TracingConstants.OTEL_SERVICE_NAME_KEY, serviceName);
         }
         if (serviceName != null && System.getenv(TracingConstants.OTEL_TRACES_EXPORTER_ENV) == null) {
-            System.setProperty(TracingConstants.OTEL_TRACES_EXPORTER_KEY, TracingConstants.JAEGER);
+            System.setProperty(TracingConstants.OTEL_TRACES_EXPORTER_KEY, TracingConstants.OTLP_EXPORTER);
         }
         return serviceName;
     }

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
+@Deprecated
 public class OpenTracingHandle implements TracingHandle {
     @Override
     public String getType() {

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingConstants.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingConstants.java
@@ -21,7 +21,7 @@ public final class TracingConstants {
     public static final String TEST_CLIENTS = "test-clients";
 
     /**
-     * Common constants for Jaeger etc.
+     * Exporter related constants
      */
-    public static final String JAEGER = "jaeger";
+    public static final String OTLP_EXPORTER = "otlp";
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR changing few things:

1. Deprecates `OpenTracing` handler, which should be then removed in future version of `test-clients`
2. Changes the default OTel exporter to `OTLP`
3. Adding a bit of documentation, what should be set for running tracing clients (like usage of `TRACING_TYPE`)