### PR TITLE
Use client supplier wrapper for Kafka Streams client

### DIFF
--- a/kafka/streams/src/main/java/Main.java
+++ b/kafka/streams/src/main/java/Main.java
@@ -37,9 +37,7 @@ public class Main {
 
         Topology topology = builder.build();
 
-        TracingUtil.initialize().addTracingPropsToStreamsConfig(props);
-
-        KafkaStreams streams = new KafkaStreams(topology, props);
+        KafkaStreams streams = TracingUtil.initialize().getStreamsWithTracing(topology, props);
 
         streams.start();
     }

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
@@ -19,6 +19,9 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -62,9 +65,9 @@ public class OpenTelemetryHandle implements TracingHandle {
     }
 
     @Override
-    public void addTracingPropsToStreamsConfig(Properties props) {
-        addTracingPropsToConsumerConfig(props);
-        addTracingPropsToProducerConfig(props);
+    public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
+        KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
+        return new KafkaStreams(topology, props, supplier);
     }
 
     @Override

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
@@ -15,6 +15,8 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -49,10 +51,10 @@ public class OpenTracingHandle implements TracingHandle {
         TracingUtil.addProperty(props, ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingProducerInterceptor.class.getName());
     }
 
+    // KafkaStreams is not working with OpenTracing from Kafka 3.0.0
     @Override
-    public void addTracingPropsToStreamsConfig(Properties props) {
-        addTracingPropsToConsumerConfig(props);
-        addTracingPropsToProducerConfig(props);
+    public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
+        return null;
     }
 
     @Override

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingHandle.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.test.tracing;
 
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+
 import java.util.Properties;
 
 /**
@@ -16,7 +19,8 @@ public interface TracingHandle {
 
     void addTracingPropsToConsumerConfig(Properties props);
     void addTracingPropsToProducerConfig(Properties props);
-    void addTracingPropsToStreamsConfig(Properties props);
+
+    KafkaStreams getStreamsWithTracing(Topology topology, Properties props);
 
     <T> HttpHandle<T> createHttpHandle(String operationName);
 }

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingKafkaClientSupplier.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingKafkaClientSupplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.test.tracing;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.kafkaclients.KafkaTelemetry;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+
+import java.util.Map;
+
+public class TracingKafkaClientSupplier extends DefaultKafkaClientSupplier {
+    @Override
+    public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+        KafkaTelemetry telemetry = KafkaTelemetry.create(GlobalOpenTelemetry.get());
+        return telemetry.wrap(super.getProducer(config));
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
+        KafkaTelemetry telemetry = KafkaTelemetry.create(GlobalOpenTelemetry.get());
+        return telemetry.wrap(super.getConsumer(config));
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
+        return this.getConsumer(config);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
+        return this.getConsumer(config);
+    }
+}

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.test.tracing;
 
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -84,7 +86,8 @@ public class TracingUtil {
         }
 
         @Override
-        public void addTracingPropsToStreamsConfig(Properties props) {
+        public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
This PR fixes issue with deploying Kafka Streams client - it seems that with previous implementation, the `Consumer` inside `Kafka Streams` was not able to be deployed, because of the wrong names of the interceptor classes (they have been overwritten).

Instead of using the interceptor classes in properties directly, this PR adds new `TracingKafkaClientSupplier`, which extends the `DefaultKafkaClientSupplier` for creating `KafkaStreams` application with tracing configuration.