### PR TITLE
Specify HTTP 1.1 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@
 .idea/
 *.iml
 
+# VS Code
+.factorypath
+.vscode
+
 **/dependency-reduced-pom.xml

--- a/tracing/src/main/java/io/strimzi/test/tracing/HttpHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/HttpHandle.java
@@ -6,6 +6,7 @@ package io.strimzi.test.tracing;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
@@ -18,7 +19,8 @@ public class HttpHandle<T> {
         try {
             HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(new URI(context.getUri()))
-                .setHeader(context.getHeaderKey(), context.getHeaderValue());
+                .setHeader(context.getHeaderKey(), context.getHeaderValue())
+                .version(HttpClient.Version.HTTP_1_1);
 
             if (context.getRecord() == null) {
                 builder.GET();


### PR DESCRIPTION
It seems that with new bridge version on `main` branch (maybe related to a Vert.x bump), the test-clients try to upgrade from protocol HTTP 1.1 to HTTP 2.0 which is not supported by the bridge and it closes the connection (the clients will raise and EOF exception on its side).

![image](https://user-images.githubusercontent.com/5842311/204231703-06e0b152-b78e-4d7c-a8ba-313db697cd75.png)


This PR specifies the HTTP 1.1 protocol in the HTTP request to fix this.