### PR TITLE
Move to Java 17 and update few dependencies

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -19,10 +19,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
+        'java-17':
           image: 'Ubuntu-18.04'
-          jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -1,10 +1,10 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 8
+# We use openjdk-X, where X is Java version (11 or 17). Images are based on Java 17
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+    default: '/usr/lib/jvm/java-17-openjdk-amd64'
   - name: JDK_VERSION
-    default: '1.8'
+    default: '17'
 steps:
 
   - bash: |
@@ -12,9 +12,9 @@ steps:
     displayName: 'Update package list'
 
   - bash: |
-      sudo apt-get install openjdk-8-jdk
-    displayName: 'Install openjdk8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
+      sudo apt-get install openjdk-17-jdk
+    displayName: 'Install openjdk17'
+    condition: eq(variables['JDK_VERSION'], '17')
 
   - bash: |
       sudo apt-get install openjdk-11-jdk
@@ -22,10 +22,10 @@ steps:
     condition: eq(variables['JDK_VERSION'], '11')
 
   - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
-    displayName: 'Setup JAVA_VERSION=1.8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
+      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+      echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+    displayName: 'Setup JAVA_VERSION=17'
+    condition: eq(variables['JDK_VERSION'], '17')
 
   - bash: |
       echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"

--- a/http/http-consumer/Dockerfile
+++ b/http/http-consumer/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/http/http-producer/Dockerfile
+++ b/http/http-producer/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/kafka/admin/Dockerfile
+++ b/kafka/admin/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/kafka/consumer/Dockerfile
+++ b/kafka/consumer/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/kafka/producer/Dockerfile
+++ b/kafka/producer/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/kafka/streams/Dockerfile
+++ b/kafka/streams/Dockerfile
@@ -2,12 +2,14 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 USER root
 
+ARG JAVA_VERSION=17
+
 RUN microdnf update \
-    && microdnf install java-11-openjdk-headless shadow-utils \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-17
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,11 @@
     </modules>
 
     <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <log4j.version>2.17.2</log4j.version>
+        <log4j.version>2.19.0</log4j.version>
         <slf4j-simple.version>1.6.2</slf4j-simple.version>
         <kafka.version>3.3.1</kafka.version>
         <strimzi-oauth-callback.version>0.11.0</strimzi-oauth-callback.version>
@@ -27,7 +28,7 @@
         <netty.version>4.1.72.Final</netty.version>
         <jackson.version>2.13.1</jackson.version>
         <maven-shade.version>3.2.1</maven-shade.version>
-        <kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
         <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <netty.version>4.1.72.Final</netty.version>
         <jackson.version>2.13.1</jackson.version>
         <maven-shade.version>3.2.1</maven-shade.version>
-        <kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
+        <kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
         <jaeger.version>1.8.1</jaeger.version>
         <opentracing.version>0.33.0</opentracing.version>
         <opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR removes support for Java 8 and adds support for Java 17,  which is used on language and also runtime level.

Also this PR bumps `log4j2` and K8s config provider deps.