### PR TITLE
Refactor HTTP consumer

### DIFF
--- a/clients/src/main/java/io/strimzi/Main.java
+++ b/clients/src/main/java/io/strimzi/Main.java
@@ -2,16 +2,41 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 package io.strimzi;
 
+import io.strimzi.common.ClientType;
+import io.strimzi.common.ClientsInterface;
+import io.strimzi.common.configuration.Constants;
+import io.strimzi.http.consumer.HttpConsumerClient;
 import io.strimzi.http.producer.HttpProducerClient;
 import io.strimzi.test.tracing.TracingUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
 
 public class Main {
-    public static void main(String[] args) throws Exception {
+    private static final Logger LOGGER = LogManager.getLogger(Main.class);
+
+    public static void main(String[] args) {
         TracingUtil.initialize();
-        HttpProducerClient producerClient = new HttpProducerClient(System.getenv());
-        producerClient.run();
+        Map<String, String> envConfiguration = System.getenv();
+        ClientType clientType = ClientType.getFromString(envConfiguration.get(Constants.CLIENT_TYPE_ENV));
+
+        ClientsInterface client = null;
+
+        switch (clientType) {
+            case HttpProducer:
+                client = new HttpProducerClient(envConfiguration);
+                break;
+            case HttpConsumer:
+                client = new HttpConsumerClient(envConfiguration);
+                break;
+            default:
+                LOGGER.error("Unknown client type specified, exiting");
+                System.exit(-1);
+        }
+
+        client.run();
     }
 }

--- a/clients/src/main/java/io/strimzi/common/ClientType.java
+++ b/clients/src/main/java/io/strimzi/common/ClientType.java
@@ -11,4 +11,14 @@ public enum ClientType {
     KafkaStreams,
     HttpProducer,
     HttpConsumer,
+    Unknown;
+
+    public static ClientType getFromString(String value) {
+        for (ClientType type : values()) {
+            if (type.toString().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        return Unknown;
+    }
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/Constants.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/Constants.java
@@ -37,4 +37,5 @@ public interface Constants {
      */
     String CLIENT_TYPE_ENV = "CLIENT_TYPE";
 
+    String HTTP_JSON_CONTENT_TYPE = "application/vnd.kafka.json.v2+json";
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/http/HttpConsumerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/http/HttpConsumerConfiguration.java
@@ -22,6 +22,9 @@ public class HttpConsumerConfiguration extends HttpClientsConfiguration {
     private final String groupId;
     private final long pollInterval;
     private final long pollTimeout;
+    private final String consumerCreationURI;
+    private final String subscriptionURI;
+    private final String consumeMessagesURI;
 
     public HttpConsumerConfiguration(Map<String, String> map) {
         super(map);
@@ -29,6 +32,12 @@ public class HttpConsumerConfiguration extends HttpClientsConfiguration {
         this.groupId = parseStringOrDefault(map.get(GROUP_ID_ENV), DEFAULT_GROUP_ID);
         this.pollInterval = parseLongOrDefault(map.get(POLL_INTERVAL_ENV), DEFAULT_POLL_INTERVAL);
         this.pollTimeout = parseLongOrDefault(map.get(POLL_TIMEOUT_ENV), DEFAULT_POLL_TIMEOUT);
+
+        String baseUri = "http://" + this.getHostname() + ":" + this.getPort() + "/consumers/" + this.groupId;
+
+        this.consumerCreationURI =  baseUri;
+        this.subscriptionURI = baseUri + "/instances/" + this.clientId + "/subscription";
+        this.consumeMessagesURI = baseUri + "/instances/" + this.clientId + "/records?timeout=" + this.pollTimeout;
     }
 
     public String getClientId() {
@@ -45,6 +54,18 @@ public class HttpConsumerConfiguration extends HttpClientsConfiguration {
 
     public long getPollTimeout() {
         return pollTimeout;
+    }
+
+    public String getConsumerCreationURI() {
+        return consumerCreationURI;
+    }
+
+    public String getSubscriptionURI() {
+        return subscriptionURI;
+    }
+
+    public String getConsumeMessagesURI() {
+        return consumeMessagesURI;
     }
 
     @Override

--- a/clients/src/main/java/io/strimzi/common/records/http/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/io/strimzi/common/records/http/consumer/ConsumerRecord.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.records.http.consumer;
+
+import java.util.Objects;
+
+public class ConsumerRecord {
+    private String topic;
+    private Object key;
+    private Object value;
+    private int partition;
+    private long offset;
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public void setKey(Object key) {
+        this.key = key;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public void setPartition(int partition) {
+        this.partition = partition;
+    }
+
+    public void setOffset(long offset) {
+        this.offset = offset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // self check
+        if (this == o)
+            return true;
+
+        // null check
+        if (o == null)
+            return false;
+
+        // type check and cast
+        if (getClass() != o.getClass())
+            return false;
+
+        ConsumerRecord cr = (ConsumerRecord) o;
+
+        return cr.partition == partition &&
+            cr.offset == offset &&
+            Objects.equals(cr.value, value) &&
+            Objects.equals(cr.topic, topic) &&
+            Objects.equals(cr.key, key);
+    }
+
+    @Override
+    public int hashCode() {
+        return topic.hashCode() + key.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerRecord: " +
+            ", topic = " + this.topic +
+            ", key = " + this.key +
+            ", value = " + this.value +
+            ", partition = " + this.partition +
+            ", offset = " + this.offset;
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/records/http/consumer/ConsumerRecordUtils.java
+++ b/clients/src/main/java/io/strimzi/common/records/http/consumer/ConsumerRecordUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.records.http.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ConsumerRecordUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerRecordUtils.class);
+
+    public static ConsumerRecord[] parseConsumerRecordsFromJson(String response) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.configure(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true);
+
+        return objectMapper.readValue(response, ConsumerRecord[].class);
+    }
+
+    public static void logConsumerRecords(ConsumerRecord[] records) {
+        for (ConsumerRecord record : records) {
+            LOGGER.info(record.toString());
+        }
+    }
+}

--- a/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.http.consumer;
+
+import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
+import io.strimzi.common.ClientsInterface;
+import io.strimzi.common.configuration.Constants;
+import io.strimzi.common.configuration.http.HttpConsumerConfiguration;
+import io.strimzi.common.records.http.consumer.ConsumerRecord;
+import io.strimzi.common.records.http.consumer.ConsumerRecordUtils;
+import io.strimzi.test.tracing.HttpContext;
+import io.strimzi.test.tracing.HttpHandle;
+import io.strimzi.test.tracing.TracingHandle;
+import io.strimzi.test.tracing.TracingUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class HttpConsumerClient implements ClientsInterface {
+
+    private static final Logger LOGGER = LogManager.getLogger(HttpConsumerClient.class);
+    private final HttpConsumerConfiguration configuration;
+    private int consumedMessages;
+    private HttpClient client;
+    private TracingHandle tracingHandle;
+    private HttpHandle httpHandle;
+    private final ScheduledExecutorService scheduledExecutor;
+
+    public HttpConsumerClient(Map<String, String> configuration) {
+        this.configuration = new HttpConsumerConfiguration(configuration);
+        this.consumedMessages = 0;
+        this.client = HttpClient.newHttpClient();
+        this.tracingHandle = TracingUtil.getTracing();
+        this.httpHandle = tracingHandle.createHttpHandle("receive-messages");
+        this.scheduledExecutor = Executors.newScheduledThreadPool(1, r -> new Thread(r, "http-consumer"));
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("Starting {} with configuration: \n{}", this.getClass().getName(), configuration.toString());
+
+        createConsumer();
+        subscribeToTopic();
+        scheduledExecutor.scheduleWithFixedDelay(this::checkAndReceiveMessages, 0, configuration.getPollInterval(), TimeUnit.MILLISECONDS);
+
+        awaitCompletion();
+    }
+
+    @Override
+    public void awaitCompletion() {
+        try {
+            long timeoutForOperations = configuration.getMessageCount() * configuration.getPollInterval() + Constants.DEFAULT_TASK_COMPLETION_TIMEOUT;
+            scheduledExecutor.awaitTermination(timeoutForOperations, TimeUnit.MILLISECONDS);
+
+            if (consumedMessages >= configuration.getMessageCount()) {
+                LOGGER.info("All messages successfully received");
+            } else {
+                LOGGER.error("Unable to correctly receive all messages");
+                throw new RuntimeException("Failed to receive all messages");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error("Failed to wait for task completion due to: {}", e.getMessage());
+            e.printStackTrace();
+        } finally {
+            if (!scheduledExecutor.isShutdown()) {
+                scheduledExecutor.shutdownNow();
+            }
+        }
+    }
+
+    private void checkAndReceiveMessages() {
+        if (consumedMessages >= configuration.getMessageCount()) {
+            scheduledExecutor.shutdown();
+        } else {
+            this.consumeMessages();
+        }
+    }
+
+    public void createConsumer() {
+        String message = "{\"name\":\"" + configuration.getClientId() + "\",\"format\":\"json\",\"auto.offset.reset\":\"earliest\"}";
+
+        LOGGER.info("Creating new consumer:\n{}", message);
+
+        HttpContext context = HttpContext.post(configuration.getConsumerCreationURI(), Constants.HTTP_JSON_CONTENT_TYPE, message);
+
+        HttpHandle<String> httpHandle = TracingUtil.getTracing().createHttpHandle("create-consumer");
+        HttpRequest creationRequest = httpHandle.build(context);
+
+        try {
+            HttpResponse<String> response = client.send(creationRequest, HttpResponse.BodyHandlers.ofString());
+            httpHandle.finish(response);
+
+            if (response.statusCode() == HttpResponseStatus.OK.code()) {
+                LOGGER.info("Consumer successfully created. Response:\n{}", response.body());
+            } else {
+                throw new RuntimeException(String.format("Failed to create consumer. Status code: %s, response: %s", response.statusCode(), response.body()));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(String.format("Failed to create consumer: %s due to: %s", configuration.getClientId(), e.getMessage()));
+        }
+    }
+
+    public void subscribeToTopic() {
+        String subscriptionMessage = "{\"topics\":[\"" + configuration.getTopic() + "\"]}";
+
+        LOGGER.info("Subscribing consumer: {} to topic: {} with message: {}", configuration.getClientId(), configuration.getTopic(), subscriptionMessage);
+
+        HttpContext context = HttpContext.post(configuration.getSubscriptionURI(), Constants.HTTP_JSON_CONTENT_TYPE, subscriptionMessage);
+
+        HttpHandle<String> httpHandle = TracingUtil.getTracing().createHttpHandle("subscribe-topic");
+        HttpRequest subscriptionRequest = httpHandle.build(context);
+
+        try {
+            HttpResponse<String> response = client.send(subscriptionRequest, HttpResponse.BodyHandlers.ofString());
+            httpHandle.finish(response);
+
+            if (response.statusCode() == HttpResponseStatus.NO_CONTENT.code()) {
+                LOGGER.info("Successfully subscribed to topic {}. Response:\n{}", configuration.getTopic(), response.body());
+            } else {
+                throw new RuntimeException(String.format("Failed to subscribe consumer: %s to topic: %s. Response: %s", configuration.getClientId(), configuration.getTopic(), response.body()));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(String.format("Failed to subscribe consumer: %s to topic: %s due to: %s", configuration.getClientId(), configuration.getTopic(), e.getMessage()));
+        }
+    }
+
+    public void consumeMessages() {
+        HttpContext context = HttpContext.get(configuration.getConsumeMessagesURI(), Constants.HTTP_JSON_CONTENT_TYPE);
+        try {
+            HttpResponse httpResponse = httpHandle.finish(client.send(httpHandle.build(context), HttpResponse.BodyHandlers.ofString()));
+
+            if (httpResponse.statusCode() != HttpResponseStatus.OK.code()) {
+                throw new RuntimeException("Failed to receive messages due to: " + httpResponse.body());
+            } else if (httpResponse.body().equals("[]") && httpResponse.statusCode() == HttpResponseStatus.OK.code()) {
+                LOGGER.info("Array with messages is empty, no messages were received");
+            } else {
+                ConsumerRecord[] records = ConsumerRecordUtils.parseConsumerRecordsFromJson(httpResponse.body().toString());
+                ConsumerRecordUtils.logConsumerRecords(records);
+
+                consumedMessages += records.length;
+            }
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to consume message due to: {}", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/configuration/http/HttpConsumerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/common/configuration/http/HttpConsumerConfigurationTest.java
@@ -25,10 +25,17 @@ public class HttpConsumerConfigurationTest {
     void testDefaultConfiguration() {
         HttpConsumerConfiguration consumerConfiguration = new HttpConsumerConfiguration(defaultConfiguration);
 
+        String baseUri = "http://localhost:8080/consumers/" + Constants.DEFAULT_GROUP_ID;
+        String subscriptionUri = baseUri + "/instances/" + Constants.DEFAULT_CLIENT_ID + "/subscription";
+        String consumeUri = baseUri + "/instances/" + Constants.DEFAULT_CLIENT_ID + "/records?timeout=" + Constants.DEFAULT_POLL_TIMEOUT;
+
         assertThat(consumerConfiguration.getClientId(), is(Constants.DEFAULT_CLIENT_ID));
         assertThat(consumerConfiguration.getGroupId(), is(Constants.DEFAULT_GROUP_ID));
         assertThat(consumerConfiguration.getPollInterval(), is(Constants.DEFAULT_POLL_INTERVAL));
         assertThat(consumerConfiguration.getPollTimeout(), is(Constants.DEFAULT_POLL_TIMEOUT));
+        assertThat(consumerConfiguration.getConsumerCreationURI(), is(baseUri));
+        assertThat(consumerConfiguration.getSubscriptionURI(), is(subscriptionUri));
+        assertThat(consumerConfiguration.getConsumeMessagesURI(), is(consumeUri));
     }
 
     @Test
@@ -46,9 +53,16 @@ public class HttpConsumerConfigurationTest {
 
         HttpConsumerConfiguration consumerConfiguration = new HttpConsumerConfiguration(configuration);
 
+        String baseUri = "http://localhost:8080/consumers/" + groupId;
+        String subscriptionUri = baseUri + "/instances/" + clientId + "/subscription";
+        String consumeUri = baseUri + "/instances/" + clientId + "/records?timeout=" + pollTimeout;
+
         assertThat(consumerConfiguration.getClientId(), is(clientId));
         assertThat(consumerConfiguration.getGroupId(), is(groupId));
         assertThat(consumerConfiguration.getPollInterval(), is(pollInterval));
         assertThat(consumerConfiguration.getPollTimeout(), is(pollTimeout));
+        assertThat(consumerConfiguration.getConsumerCreationURI(), is(baseUri));
+        assertThat(consumerConfiguration.getSubscriptionURI(), is(subscriptionUri));
+        assertThat(consumerConfiguration.getConsumeMessagesURI(), is(consumeUri));
     }
 }

--- a/clients/src/test/java/io/strimzi/common/records/http/consumer/ConsumerRecordUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/http/consumer/ConsumerRecordUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.records.http.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class ConsumerRecordUtilsTest {
+
+    @Test
+    void testParseConsumerRecordsFromJson() throws JsonProcessingException {
+        String response = "[{\"topic\":\"random-topic\",\"key\":\"key-0\",\"value\":\"Hello world-0\",\"partition\":0,\"offset\":0}]";
+
+        ConsumerRecord expectedResult = new ConsumerRecord();
+        expectedResult.setPartition(0);
+        expectedResult.setOffset(0);
+        expectedResult.setTopic("random-topic");
+        expectedResult.setKey("key-0");
+        expectedResult.setValue("Hello world-0");
+
+        ConsumerRecord[] result = ConsumerRecordUtils.parseConsumerRecordsFromJson(response);
+
+        assertThat(result.length, is(1));
+        assertThat(result[0], is(expectedResult));
+    }
+
+    @Test
+    void testParseConsumerRecordsWithWrongValue() {
+        String response = "Completely random response";
+
+        assertThrows(JsonProcessingException.class, () -> ConsumerRecordUtils.parseConsumerRecordsFromJson(response));
+    }
+}


### PR DESCRIPTION
This PR continues in refactoring clients inside this repository - now with HTTP Consumer.
Other than refactoring the HTTP consumer, it also adds switch for the clients -> and depending on `ClientType` runs particular client.