### PR TITLE
Change package for `OffsetRecordSent` and `ProducerRecord`

### DIFF
--- a/clients/src/main/java/io/strimzi/common/records/http/producer/OffsetRecordSent.java
+++ b/clients/src/main/java/io/strimzi/common/records/http/producer/OffsetRecordSent.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.http.producer;
+package io.strimzi.common.records.http.producer;
 
 public class OffsetRecordSent {
     private int partition;

--- a/clients/src/main/java/io/strimzi/common/records/http/producer/OffsetRecordSentUtils.java
+++ b/clients/src/main/java/io/strimzi/common/records/http/producer/OffsetRecordSentUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.records.http.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class OffsetRecordSentUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(OffsetRecordSentUtils.class);
+
+    public static void logOffsetRecordsSent(OffsetRecordSent[] offsetRecordsSent) {
+        for (OffsetRecordSent offsetRecordSent : offsetRecordsSent) {
+            LOGGER.info(offsetRecordSent.toString());
+        }
+    }
+
+    public static OffsetRecordSent[] parseOffsetRecordsSent(String response) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        JsonNode json = objectMapper.readTree(response);
+        String offsets = json.get("offsets").toString();
+
+        objectMapper.configure(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true);
+
+        return objectMapper.readValue(offsets, OffsetRecordSent[].class);
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/records/http/producer/ProducerRecord.java
+++ b/clients/src/main/java/io/strimzi/common/records/http/producer/ProducerRecord.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.http.producer;
+package io.strimzi.common.records.http.producer;
 
 import io.strimzi.test.tracing.HttpContext;
 

--- a/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
+++ b/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
@@ -4,14 +4,13 @@
  */
 package io.strimzi.http.producer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.common.ClientsInterface;
 import io.strimzi.common.configuration.Constants;
 import io.strimzi.common.configuration.http.HttpProducerConfiguration;
+import io.strimzi.common.records.http.producer.OffsetRecordSent;
+import io.strimzi.common.records.http.producer.OffsetRecordSentUtils;
+import io.strimzi.common.records.http.producer.ProducerRecord;
 import io.strimzi.test.tracing.HttpContext;
 import io.strimzi.test.tracing.HttpHandle;
 import io.strimzi.test.tracing.TracingHandle;
@@ -137,30 +136,13 @@ public class HttpProducerClient implements ClientsInterface {
                 LOGGER.info("Array with messages is empty, no messages were received!");
             }
 
-            OffsetRecordSent[] offsetRecordSent = parseOffsetRecordsSent(httpResponse.body().toString());
-            logOffsetRecordsSent(offsetRecordSent);
+            OffsetRecordSent[] offsetRecordSent = OffsetRecordSentUtils.parseOffsetRecordsSent(httpResponse.body().toString());
+            OffsetRecordSentUtils.logOffsetRecordsSent(offsetRecordSent);
             messageSuccessfullySent += offsetRecordSent.length;
         } catch (Exception e) {
             LOGGER.error("Caught exception during message send");
             e.printStackTrace();
             throw new RuntimeException("Failed to send message due to: " + e.getMessage());
         }
-    }
-
-    private void logOffsetRecordsSent(OffsetRecordSent[] offsetRecordsSent) {
-        for (OffsetRecordSent offsetRecordSent : offsetRecordsSent) {
-            LOGGER.info(offsetRecordSent.toString());
-        }
-    }
-
-    public OffsetRecordSent[] parseOffsetRecordsSent(String response) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        JsonNode json = objectMapper.readTree(response);
-        String offsets = json.get("offsets").toString();
-
-        objectMapper.configure(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true);
-
-        return objectMapper.readValue(offsets, OffsetRecordSent[].class);
     }
 }

--- a/clients/src/test/java/io/strimzi/common/records/http/producer/OffsetRecordSentUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/http/producer/OffsetRecordSentUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.records.http.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class OffsetRecordSentUtilsTest {
+
+    @Test
+    void testParseOffsetRecordsSent() throws JsonProcessingException {
+        String responseExample = "{\"offsets\":[{\"partition\":0,\"offset\":16}]}";
+
+        OffsetRecordSent expectedResult = new OffsetRecordSent();
+        expectedResult.setOffset(16);
+        expectedResult.setPartition(0);
+
+        OffsetRecordSent[] result = OffsetRecordSentUtils.parseOffsetRecordsSent(responseExample);
+
+        assertThat(result.length, is(1));
+        assertThat(result[0], is(expectedResult));
+    }
+
+    @Test
+    void testParseConsumerRecordsWithWrongValue() {
+        String response = "Completely random response";
+
+        assertThrows(JsonProcessingException.class, () -> OffsetRecordSentUtils.parseOffsetRecordsSent(response));
+    }
+}

--- a/clients/src/test/java/io/strimzi/http/producer/HttpProducerClientTest.java
+++ b/clients/src/test/java/io/strimzi/http/producer/HttpProducerClientTest.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.http.producer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.strimzi.common.configuration.Constants;
+import io.strimzi.common.records.http.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -30,20 +30,6 @@ public class HttpProducerClientTest {
         ProducerRecord result = producerClient.generateMessage(numberOfMessage);
 
         assertThat(result.message(), is(desiredJsonMessage));
-    }
-
-    @Test
-    void testParseOffsetRecordsSent() throws JsonProcessingException {
-        String responseExample = "{\"offsets\":[{\"partition\":0,\"offset\":16}]}";
-
-        OffsetRecordSent expectedResult = new OffsetRecordSent();
-        expectedResult.setOffset(16);
-        expectedResult.setPartition(0);
-
-        OffsetRecordSent[] result = producerClient.parseOffsetRecordsSent(responseExample);
-
-        assertThat(result.length, is(1));
-        assertThat(result[0], is(expectedResult));
     }
 
     @BeforeAll


### PR DESCRIPTION
This PR moves `OffsetRecordSent` and `ProducerRecord` to different package and leaves the producer client package just for the client.

Also, this PR moves methods from `HttpProducerClient` class which are related to `OffsetRecordSent` to `OffsetRecordSentUtils`