### PR TITLE
Refactor Kafka clients

### DIFF
--- a/clients/src/main/java/io/strimzi/Main.java
+++ b/clients/src/main/java/io/strimzi/Main.java
@@ -9,6 +9,9 @@ import io.strimzi.common.ClientsInterface;
 import io.strimzi.common.configuration.Constants;
 import io.strimzi.http.consumer.HttpConsumerClient;
 import io.strimzi.http.producer.HttpProducerClient;
+import io.strimzi.kafka.KafkaConsumerClient;
+import io.strimzi.kafka.KafkaProducerClient;
+import io.strimzi.kafka.KafkaStreamsClient;
 import io.strimzi.test.tracing.TracingUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +34,15 @@ public class Main {
                 break;
             case HttpConsumer:
                 client = new HttpConsumerClient(envConfiguration);
+                break;
+            case KafkaProducer:
+                client = new KafkaProducerClient(envConfiguration);
+                break;
+            case KafkaConsumer:
+                client = new KafkaConsumerClient(envConfiguration);
+                break;
+            case KafkaStreams:
+                client = new KafkaStreamsClient(envConfiguration);
                 break;
             default:
                 LOGGER.error("Unknown client type specified, exiting");

--- a/clients/src/main/java/io/strimzi/common/SaslType.java
+++ b/clients/src/main/java/io/strimzi/common/SaslType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common;
+
+import java.util.List;
+
+public enum SaslType {
+    PLAIN("PLAIN", "PLAIN"),
+    SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA256"),
+    SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA512"),
+    UNKNOWN("UNKNOWN", "NONE");
+
+    private final String name;
+    private final String kafkaProperty;
+
+    private SaslType(String name, String kafkaProperty) {
+        this.name = name;
+        this.kafkaProperty = kafkaProperty;
+    }
+
+    public static List<String> getAllSaslTypes() {
+        return List.of(PLAIN.name, SCRAM_SHA_256.name, SCRAM_SHA_512.name);
+    }
+
+    public String getKafkaProperty() {
+        return this.kafkaProperty;
+    }
+}
+

--- a/clients/src/main/java/io/strimzi/common/SaslType.java
+++ b/clients/src/main/java/io/strimzi/common/SaslType.java
@@ -15,7 +15,7 @@ public enum SaslType {
     private final String name;
     private final String kafkaProperty;
 
-    private SaslType(String name, String kafkaProperty) {
+    SaslType(String name, String kafkaProperty) {
         this.name = name;
         this.kafkaProperty = kafkaProperty;
     }
@@ -26,6 +26,19 @@ public enum SaslType {
 
     public String getKafkaProperty() {
         return this.kafkaProperty;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static SaslType getFromString(String value) {
+        for (SaslType type : values()) {
+            if (type.getName().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        return UNKNOWN;
     }
 }
 

--- a/clients/src/main/java/io/strimzi/common/configuration/ClientsConfigurationUtils.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/ClientsConfigurationUtils.java
@@ -4,9 +4,15 @@
  */
 package io.strimzi.common.configuration;
 
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.StringTokenizer;
 import java.util.function.Function;
 
 public class ClientsConfigurationUtils {
@@ -37,5 +43,40 @@ public class ClientsConfigurationUtils {
             returnValue = defaultValue;
         }
         return returnValue;
+    }
+
+    public static Properties parseMapOfProperties(String properties) {
+        Properties additionalProps = new Properties();
+
+        if (!properties.isEmpty()) {
+            StringTokenizer tok = new StringTokenizer(properties, System.lineSeparator());
+            while (tok.hasMoreTokens()) {
+                String record = tok.nextToken();
+                int endIndex = record.indexOf('=');
+                if (endIndex == -1) {
+                    throw new RuntimeException("Failed to parse Map from String");
+                }
+                String key = record.substring(0, endIndex);
+                String value = record.substring(endIndex + 1);
+                additionalProps.put(key.trim(), value.trim());
+            }
+        }
+
+        return additionalProps;
+    }
+
+    public static List<Header> parseHeadersFromConfiguration(String headers) {
+        List<Header> headersList = null;
+
+        if (headers != null) {
+            headersList = new ArrayList<>();
+
+            String[] headersArray = headers.split(", [\t\n\r]?");
+            for (String header : headersArray) {
+                headersList.add(new RecordHeader(header.split("=")[0], header.split("=")[1].getBytes()));
+            }
+        }
+
+        return headersList;
     }
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/ClientsConfigurationUtils.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/ClientsConfigurationUtils.java
@@ -73,6 +73,9 @@ public class ClientsConfigurationUtils {
 
             String[] headersArray = headers.split(", [\t\n\r]?");
             for (String header : headersArray) {
+                if (header.indexOf('=') == -1) {
+                    throw new RuntimeException("Failed to parse Headers from String");
+                }
                 headersList.add(new RecordHeader(header.split("=")[0], header.split("=")[1].getBytes()));
             }
         }

--- a/clients/src/main/java/io/strimzi/common/configuration/Constants.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/Constants.java
@@ -14,23 +14,59 @@ public interface Constants {
     long DEFAULT_POLL_INTERVAL = 1000;
     long DEFAULT_POLL_TIMEOUT = 100;
     long DEFAULT_TASK_COMPLETION_TIMEOUT = 60000;
+    String DEFAULT_PRODUCER_ACKS = "1";
+    long DEFAULT_COMMIT_INTERVAL_MS = 5000;
+    int DEFAULT_MESSAGES_PER_TRANSACTION = 10;
 
     /**
      * HTTP constants
      */
     String DEFAULT_ENDPOINT_PREFIX = "";
 
+    /**
+     * HTTP environment variables
+     */
     String HOSTNAME_ENV = "HOSTNAME";
     String PORT_ENV = "PORT";
-    String TOPIC_ENV = "TOPIC";
-    String DELAY_MS_ENV = "DELAY_MS";
-    String MESSAGE_COUNT_ENV = "MESSAGE_COUNT";
-    String MESSAGE_ENV = "MESSAGE";
     String ENDPOINT_PREFIX_ENV = "ENDPOINT_PREFIX";
     String CLIENT_ID_ENV = "CLIENT_ID";
-    String GROUP_ID_ENV = "GROUP_ID";
     String POLL_INTERVAL_ENV = "POLL_INTERVAL";
     String POLL_TIMEOUT_ENV = "POLL_TIMEOUT";
+
+    /**
+     * Common environment variables
+     */
+    String GROUP_ID_ENV = "GROUP_ID";
+    String TOPIC_ENV = "TOPIC";
+    String MESSAGE_COUNT_ENV = "MESSAGE_COUNT";
+    String DELAY_MS_ENV = "DELAY_MS";
+    String MESSAGE_ENV = "MESSAGE";
+
+    /**
+     * Kafka environment variables
+     */
+    String BOOTSTRAP_SERVERS_ENV = "BOOTSTRAP_SERVERS";
+    String APPLICATION_ID_ENV = "APPLICATION_ID";
+    String SOURCE_TOPIC_ENV = "SOURCE_TOPIC";
+    String TARGET_TOPIC_ENV = "TARGET_TOPIC";
+    String SASL_JAAS_CONFIG_ENV = "SASL_JAAS_CONFIG";
+    String USER_NAME_ENV = "USER_NAME";
+    String USER_PASSWORD_ENV = "USER_PASSWORD";
+    String SASL_MECHANISM_ENV = "SASL_MECHANISM_ENV";
+    String COMMIT_INTERVAL_MS_ENV = "COMMIT_INTERVAL_MS";
+    String PRODUCER_ACKS_ENV = "PRODUCER_ACKS";
+    String CLIENT_RACK_ENV = "CLIENT_RACK";
+    String CA_CRT_ENV = "CA_CRT";
+    String USER_KEY_ENV = "USER_KEY";
+    String USER_CERT_ENV = "USER_CERT";
+    String OAUTH_CLIENT_ID_ENV = "OAUTH_CLIENT_ID";
+    String OAUTH_CLIENT_SECRET_ENV = "OAUTH_CLIENT_SECRET";
+    String OAUTH_ACCESS_TOKEN_ENV = "OAUTH_ACCESS_TOKEN";
+    String OAUTH_REFRESH_TOKEN_ENV = "OAUTH_REFRESH_TOKEN";
+    String OAUTH_TOKEN_ENDPOINT_URI_ENV = "OAUTH_TOKEN_ENDPOINT_URI";
+    String HEADERS_ENV = "HEADERS";
+    String MESSAGES_PER_TRANSACTION_ENV = "MESSAGES_PER_TRANSACTION";
+    String ADDITIONAL_CONFIG_ENV = "ADDITIONAL_CONFIG";
 
     /**
      * Common environment variables

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseIntOrDefault;
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseLongOrDefault;
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseMapOfProperties;
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.common.configuration.Constants.ADDITIONAL_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.CA_CRT_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_DELAY_MS;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGES_COUNT;
+import static io.strimzi.common.configuration.Constants.DELAY_MS_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGE_COUNT_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_ACCESS_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_SECRET_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_REFRESH_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_JAAS_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_MECHANISM_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.USER_CERT_ENV;
+import static io.strimzi.common.configuration.Constants.USER_KEY_ENV;
+import static io.strimzi.common.configuration.Constants.USER_NAME_ENV;
+import static io.strimzi.common.configuration.Constants.USER_PASSWORD_ENV;
+
+public class KafkaClientsConfiguration {
+    private final String bootstrapServers;
+    private final long delayMs;
+    private final String topicName;
+    private final int messageCount;
+    private final String sslTruststoreCertificate;
+    private final String sslKeystoreKey;
+    private final String sslKeystoreCertificateChain;
+    private final String oauthClientId;
+    private final String oauthClientSecret;
+    private final String oauthAccessToken;
+    private final String oauthRefreshToken;
+    private final String oauthTokenEndpointUri;
+    private final Properties additionalConfig;
+    private final String saslMechanism;
+    private final String saslJaasConfig;
+    private final String saslUserName;
+    private final String saslPassword;
+    private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
+
+    public KafkaClientsConfiguration(Map<String, String> map) {
+        this.bootstrapServers = map.get(BOOTSTRAP_SERVERS_ENV);
+        this.delayMs = parseLongOrDefault(map.get(DELAY_MS_ENV), DEFAULT_DELAY_MS);
+        this.topicName = map.get(TOPIC_ENV);
+        this.messageCount = parseIntOrDefault(map.get(MESSAGE_COUNT_ENV), DEFAULT_MESSAGES_COUNT);
+        this.sslTruststoreCertificate = map.get(CA_CRT_ENV);
+        this.sslKeystoreKey = map.get(USER_KEY_ENV);
+        this.sslKeystoreCertificateChain = map.get(USER_CERT_ENV);
+        this.oauthClientId = map.get(OAUTH_CLIENT_ID_ENV);
+        this.oauthClientSecret = map.get(OAUTH_CLIENT_SECRET_ENV);
+        this.oauthAccessToken = map.get(OAUTH_ACCESS_TOKEN_ENV);
+        this.oauthRefreshToken = map.get(OAUTH_REFRESH_TOKEN_ENV);
+        this.oauthTokenEndpointUri = map.get(OAUTH_TOKEN_ENDPOINT_URI_ENV);
+        this.saslMechanism = map.get(SASL_MECHANISM_ENV);
+        this.saslJaasConfig = map.get(SASL_JAAS_CONFIG_ENV);
+        this.saslUserName = map.get(USER_NAME_ENV);
+        this.saslPassword = map.get(USER_PASSWORD_ENV);
+        this.additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public long getDelayMs() {
+        return delayMs;
+    }
+
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public int getMessageCount() {
+        return messageCount;
+    }
+
+    public String getSslTruststoreCertificate() {
+        return sslTruststoreCertificate;
+    }
+
+    public String getSslKeystoreKey() {
+        return sslKeystoreKey;
+    }
+
+    public String getSslKeystoreCertificateChain() {
+        return sslKeystoreCertificateChain;
+    }
+
+    public String getOauthClientId() {
+        return oauthClientId;
+    }
+
+    public String getOauthClientSecret() {
+        return oauthClientSecret;
+    }
+
+    public String getOauthAccessToken() {
+        return oauthAccessToken;
+    }
+
+    public String getOauthRefreshToken() {
+        return oauthRefreshToken;
+    }
+
+    public String getOauthTokenEndpointUri() {
+        return oauthTokenEndpointUri;
+    }
+
+    public String getSaslMechanism() {
+        return saslMechanism;
+    }
+
+    public String getSaslJaasConfig() {
+        return saslJaasConfig;
+    }
+
+    public String getSaslUserName() {
+        return saslUserName;
+    }
+
+    public String getSaslPassword() {
+        return saslPassword;
+    }
+
+    public Properties getAdditionalConfig() {
+        return additionalConfig;
+    }
+
+    public String getSaslLoginCallbackClass() {
+        return saslLoginCallbackClass;
+    }
+
+    @Override
+    public String toString() {
+        String sslTruststoreCertificate =
+            this.getSslTruststoreCertificate() == null ? null : "[CA CRT]";
+
+        String sslKeystoreKey =
+            this.getSslKeystoreKey() == null ? null : "[USER KEY]";
+
+        String sslKeystoreCertificateChain =
+            this.getSslKeystoreCertificateChain() == null ? null : "[USER CERT]";
+
+        String oauthClientSecret =
+            this.getOauthClientSecret() == null ? null : "[OAUTH CLIENT SECRET]";
+
+        String oauthAccessToken =
+            this.getOauthAccessToken() == null ? null : "[OAUTH ACCESS TOKEN]";
+
+        String oauthRefreshToken =
+            this.getOauthRefreshToken() == null ? null : "[OAUTH REFRESH TOKEN]";
+
+        String saslJaasConfig =
+            this.getSaslJaasConfig() == null ? null : "[SASL JAAS CONFIG]";
+
+        String saslPassword =
+            this.getSaslPassword() == null ? null : "[SASL PASSWORD]";
+
+        return "bootstrapServers='" + this.getBootstrapServers() + "',\n" +
+            "delayMs='" + this.getDelayMs() + "',\n" +
+            "topicName='" + this.getTopicName() + "',\n" +
+            "messageCount='" + this.getMessageCount() + "',\n" +
+            "sslTruststoreCertificate='" + sslTruststoreCertificate + "',\n" +
+            "sslKeystoreKey='" + sslKeystoreKey + "',\n" +
+            "sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + "',\n" +
+            "oauthClientId='" + this.getOauthClientId() + "',\n" +
+            "oauthClientSecret='" + oauthClientSecret + "',\n" +
+            "oauthAccessToken='" + oauthAccessToken + "',\n" +
+            "oauthRefreshToken='" + oauthRefreshToken + "',\n" +
+            "oauthTokenEndpointUri='" + this.getOauthTokenEndpointUri() + "',\n" +
+            "saslMechanism='" + this.getSaslMechanism() + "',\n" +
+            "saslJaasConfig='" + saslJaasConfig + "',\n" +
+            "saslUserName='" + this.getSaslUserName() + "',\n" +
+            "saslPassword='" + saslPassword + "',\n" +
+            "additionalConfig='" + this.getAdditionalConfig() + "'";
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.common.configuration.kafka;
 
+import java.security.InvalidParameterException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -25,7 +26,6 @@ import static io.strimzi.common.configuration.Constants.OAUTH_REFRESH_TOKEN_ENV;
 import static io.strimzi.common.configuration.Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
 import static io.strimzi.common.configuration.Constants.SASL_JAAS_CONFIG_ENV;
 import static io.strimzi.common.configuration.Constants.SASL_MECHANISM_ENV;
-import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
 import static io.strimzi.common.configuration.Constants.USER_CERT_ENV;
 import static io.strimzi.common.configuration.Constants.USER_KEY_ENV;
 import static io.strimzi.common.configuration.Constants.USER_NAME_ENV;
@@ -34,7 +34,6 @@ import static io.strimzi.common.configuration.Constants.USER_PASSWORD_ENV;
 public class KafkaClientsConfiguration {
     private final String bootstrapServers;
     private final long delayMs;
-    private final String topicName;
     private final int messageCount;
     private final String sslTruststoreCertificate;
     private final String sslKeystoreKey;
@@ -54,7 +53,6 @@ public class KafkaClientsConfiguration {
     public KafkaClientsConfiguration(Map<String, String> map) {
         this.bootstrapServers = map.get(BOOTSTRAP_SERVERS_ENV);
         this.delayMs = parseLongOrDefault(map.get(DELAY_MS_ENV), DEFAULT_DELAY_MS);
-        this.topicName = map.get(TOPIC_ENV);
         this.messageCount = parseIntOrDefault(map.get(MESSAGE_COUNT_ENV), DEFAULT_MESSAGES_COUNT);
         this.sslTruststoreCertificate = map.get(CA_CRT_ENV);
         this.sslKeystoreKey = map.get(USER_KEY_ENV);
@@ -69,6 +67,8 @@ public class KafkaClientsConfiguration {
         this.saslUserName = map.get(USER_NAME_ENV);
         this.saslPassword = map.get(USER_PASSWORD_ENV);
         this.additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+
+        if (bootstrapServers == null || bootstrapServers.isEmpty()) throw new InvalidParameterException("Bootstrap servers are not set");
     }
 
     public String getBootstrapServers() {
@@ -77,10 +77,6 @@ public class KafkaClientsConfiguration {
 
     public long getDelayMs() {
         return delayMs;
-    }
-
-    public String getTopicName() {
-        return topicName;
     }
 
     public int getMessageCount() {
@@ -171,7 +167,6 @@ public class KafkaClientsConfiguration {
 
         return "bootstrapServers='" + this.getBootstrapServers() + "',\n" +
             "delayMs='" + this.getDelayMs() + "',\n" +
-            "topicName='" + this.getTopicName() + "',\n" +
             "messageCount='" + this.getMessageCount() + "',\n" +
             "sslTruststoreCertificate='" + sslTruststoreCertificate + "',\n" +
             "sslKeystoreKey='" + sslKeystoreKey + "',\n" +

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import java.util.Map;
+
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.common.configuration.Constants.CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.CLIENT_RACK_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_CLIENT_ID;
+import static io.strimzi.common.configuration.Constants.DEFAULT_GROUP_ID;
+import static io.strimzi.common.configuration.Constants.GROUP_ID_ENV;
+
+public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
+    private final String groupId;
+    private final String clientId;
+    private final String clientRack;
+
+    public KafkaConsumerConfiguration(Map<String, String> map) {
+        super(map);
+        this.groupId = parseStringOrDefault(map.get(GROUP_ID_ENV), DEFAULT_GROUP_ID);
+        this.clientId = parseStringOrDefault(map.get(CLIENT_ID_ENV), DEFAULT_CLIENT_ID);
+        this.clientRack = map.get(CLIENT_RACK_ENV);
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientRack() {
+        return clientRack;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaConsumerConfiguration:\n" +
+            super.toString() + ",\n" +
+            "groupId='" + this.getGroupId() + "',\n" +
+            "clientId='" + this.getClientId() + "',\n" +
+            "clientRack='" + this.getClientRack() + "'";
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfiguration.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.common.configuration.kafka;
 
+import java.security.InvalidParameterException;
 import java.util.Map;
 
 import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseStringOrDefault;
@@ -12,17 +13,22 @@ import static io.strimzi.common.configuration.Constants.CLIENT_RACK_ENV;
 import static io.strimzi.common.configuration.Constants.DEFAULT_CLIENT_ID;
 import static io.strimzi.common.configuration.Constants.DEFAULT_GROUP_ID;
 import static io.strimzi.common.configuration.Constants.GROUP_ID_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
 
 public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
     private final String groupId;
     private final String clientId;
     private final String clientRack;
+    private final String topicName;
 
     public KafkaConsumerConfiguration(Map<String, String> map) {
         super(map);
         this.groupId = parseStringOrDefault(map.get(GROUP_ID_ENV), DEFAULT_GROUP_ID);
         this.clientId = parseStringOrDefault(map.get(CLIENT_ID_ENV), DEFAULT_CLIENT_ID);
         this.clientRack = map.get(CLIENT_RACK_ENV);
+        this.topicName = map.get(TOPIC_ENV);
+
+        if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
     }
 
     public String getGroupId() {
@@ -37,12 +43,17 @@ public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
         return clientRack;
     }
 
+    public String getTopicName() {
+        return topicName;
+    }
+
     @Override
     public String toString() {
         return "KafkaConsumerConfiguration:\n" +
             super.toString() + ",\n" +
             "groupId='" + this.getGroupId() + "',\n" +
             "clientId='" + this.getClientId() + "',\n" +
-            "clientRack='" + this.getClientRack() + "'";
+            "clientRack='" + this.getClientRack() + "',\n" +
+            "topicName='" + this.getTopicName() + "'";
     }
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaProducerConfiguration.java
@@ -7,6 +7,7 @@ package io.strimzi.common.configuration.kafka;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
 
+import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
 
@@ -20,12 +21,14 @@ import static io.strimzi.common.configuration.Constants.HEADERS_ENV;
 import static io.strimzi.common.configuration.Constants.MESSAGES_PER_TRANSACTION_ENV;
 import static io.strimzi.common.configuration.Constants.MESSAGE_ENV;
 import static io.strimzi.common.configuration.Constants.PRODUCER_ACKS_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
 
 public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
 
     private final String acks;
     private final List<Header> headers;
     private final int messagesPerTransaction;
+    private final String topicName;
     private final boolean transactionalProducer;
     private final String message;
     public KafkaProducerConfiguration(Map<String, String> map) {
@@ -33,9 +36,11 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.acks = parseStringOrDefault(map.get(PRODUCER_ACKS_ENV), DEFAULT_PRODUCER_ACKS);
         this.headers = parseHeadersFromConfiguration(parseStringOrDefault(map.get(HEADERS_ENV), null));
         this.messagesPerTransaction = parseIntOrDefault(map.get(MESSAGES_PER_TRANSACTION_ENV), DEFAULT_MESSAGES_PER_TRANSACTION);
-        this.transactionalProducer = getAdditionalConfig().contains(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
+        this.transactionalProducer = getAdditionalConfig().toString().contains(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
         this.message = parseStringOrDefault(map.get(MESSAGE_ENV), DEFAULT_MESSAGE);
+        this.topicName = map.get(TOPIC_ENV);
 
+        if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
     }
 
     public String getAcks() {
@@ -48,6 +53,10 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
 
     public int getMessagesPerTransaction() {
         return messagesPerTransaction;
+    }
+
+    public String getTopicName() {
+        return topicName;
     }
 
     public boolean isTransactionalProducer() {
@@ -64,6 +73,7 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
             super.toString() + ",\n" +
             "acks='" + this.getAcks() + "',\n" +
             "headers='" + this.getHeaders() + "',\n" +
+            "topicName='" + this.getTopicName() + "',\n" +
             "message='" + this.getMessage() + "'";
     }
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaProducerConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Header;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseHeadersFromConfiguration;
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseIntOrDefault;
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGE;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGES_PER_TRANSACTION;
+import static io.strimzi.common.configuration.Constants.DEFAULT_PRODUCER_ACKS;
+import static io.strimzi.common.configuration.Constants.HEADERS_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGES_PER_TRANSACTION_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGE_ENV;
+import static io.strimzi.common.configuration.Constants.PRODUCER_ACKS_ENV;
+
+public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
+
+    private final String acks;
+    private final List<Header> headers;
+    private final int messagesPerTransaction;
+    private final boolean transactionalProducer;
+    private final String message;
+    public KafkaProducerConfiguration(Map<String, String> map) {
+        super(map);
+        this.acks = parseStringOrDefault(map.get(PRODUCER_ACKS_ENV), DEFAULT_PRODUCER_ACKS);
+        this.headers = parseHeadersFromConfiguration(parseStringOrDefault(map.get(HEADERS_ENV), null));
+        this.messagesPerTransaction = parseIntOrDefault(map.get(MESSAGES_PER_TRANSACTION_ENV), DEFAULT_MESSAGES_PER_TRANSACTION);
+        this.transactionalProducer = getAdditionalConfig().contains(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
+        this.message = parseStringOrDefault(map.get(MESSAGE_ENV), DEFAULT_MESSAGE);
+
+    }
+
+    public String getAcks() {
+        return acks;
+    }
+
+    public List<Header> getHeaders() {
+        return headers;
+    }
+
+    public int getMessagesPerTransaction() {
+        return messagesPerTransaction;
+    }
+
+    public boolean isTransactionalProducer() {
+        return transactionalProducer;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaProducerConfiguration:\n" +
+            super.toString() + ",\n" +
+            "acks='" + this.getAcks() + "',\n" +
+            "headers='" + this.getHeaders() + "',\n" +
+            "message='" + this.getMessage() + "'";
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import java.util.Map;
+
+import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseLongOrDefault;
+import static io.strimzi.common.configuration.Constants.APPLICATION_ID_ENV;
+import static io.strimzi.common.configuration.Constants.COMMIT_INTERVAL_MS_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_COMMIT_INTERVAL_MS;
+import static io.strimzi.common.configuration.Constants.SOURCE_TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.TARGET_TOPIC_ENV;
+
+public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
+    private final String applicationId;
+    private final String sourceTopic;
+    private final String targetTopic;
+    private final long commitIntervalMs;
+
+    public KafkaStreamsConfiguration(Map<String, String> map) {
+        super(map);
+        this.applicationId = map.get(APPLICATION_ID_ENV);
+        this.sourceTopic = map.get(SOURCE_TOPIC_ENV);
+        this.targetTopic = map.get(TARGET_TOPIC_ENV);
+        this.commitIntervalMs = parseLongOrDefault(map.get(COMMIT_INTERVAL_MS_ENV), DEFAULT_COMMIT_INTERVAL_MS);
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public String getSourceTopic() {
+        return sourceTopic;
+    }
+
+    public String getTargetTopic() {
+        return targetTopic;
+    }
+
+    public long getCommitIntervalMs() {
+        return commitIntervalMs;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaStreamsConfiguration:\n" +
+            super.toString() + ",\n" +
+            "applicationId='" + this.getApplicationId() + "',\n" +
+            "sourceTopic='" + this.getSourceTopic() + "',\n" +
+            "targetTopic='" + this.getTargetTopic() + "',\n" +
+            "commitIntervalMs='" + this.getCommitIntervalMs() + "'";
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfiguration.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.common.configuration.kafka;
 
+import java.security.InvalidParameterException;
 import java.util.Map;
 
 import static io.strimzi.common.configuration.ClientsConfigurationUtils.parseLongOrDefault;
@@ -25,6 +26,12 @@ public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
         this.sourceTopic = map.get(SOURCE_TOPIC_ENV);
         this.targetTopic = map.get(TARGET_TOPIC_ENV);
         this.commitIntervalMs = parseLongOrDefault(map.get(COMMIT_INTERVAL_MS_ENV), DEFAULT_COMMIT_INTERVAL_MS);
+
+        if (applicationId == null || applicationId.isEmpty()) throw new InvalidParameterException("Application ID is not set");
+
+        if (sourceTopic == null || sourceTopic.isEmpty()) throw new InvalidParameterException("Source topic is not set");
+
+        if (targetTopic == null || targetTopic.isEmpty()) throw new InvalidParameterException("Target topic is not set");
     }
 
     public String getApplicationId() {

--- a/clients/src/main/java/io/strimzi/common/properties/KafkaProperties.java
+++ b/clients/src/main/java/io/strimzi/common/properties/KafkaProperties.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.properties;
+
+import io.strimzi.common.SaslType;
+import io.strimzi.common.configuration.kafka.KafkaClientsConfiguration;
+import io.strimzi.common.configuration.kafka.KafkaConsumerConfiguration;
+import io.strimzi.common.configuration.kafka.KafkaProducerConfiguration;
+import io.strimzi.common.configuration.kafka.KafkaStreamsConfiguration;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramLoginModule;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsConfig;
+
+import java.util.Properties;
+
+public class KafkaProperties {
+    public static Properties producerProperties(KafkaProducerConfiguration configuration) {
+        Properties properties = clientProperties(configuration);
+
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.ACKS_CONFIG, configuration.getAcks());
+
+        return properties;
+    }
+
+    public static Properties consumerProperties(KafkaConsumerConfiguration configuration) {
+        Properties properties = clientProperties(configuration);
+
+        properties.put(ConsumerConfig.CLIENT_ID_CONFIG, configuration.getClientId());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, configuration.getGroupId());
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+
+        return properties;
+    }
+
+    public static Properties streamsProperties(KafkaStreamsConfiguration configuration) {
+        Properties properties = clientProperties(configuration);
+
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, configuration.getApplicationId());
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, configuration.getBootstrapServers());
+        properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, configuration.getCommitIntervalMs());
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+
+        return properties;
+    }
+
+    private static Properties clientProperties(KafkaClientsConfiguration configuration) {
+        Properties properties = new Properties();
+
+        // Kubernetes Config Provider
+        properties.put("config.providers", "secrets,configmaps");
+        properties.put("config.providers.secrets.class", "io.strimzi.kafka.KubernetesSecretConfigProvider");
+        properties.put("config.providers.configmaps.class", "io.strimzi.kafka.KubernetesConfigMapConfigProvider");
+
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, configuration.getBootstrapServers());
+
+        return updatePropertiesWithSecurityConfiguration(properties, configuration);
+    }
+
+    private static Properties updatePropertiesWithSecurityConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
+        if (shouldUpdatePropertiesWithTlsConfig(configuration)) {
+            properties = updatePropertiesWithTlsConfiguration(properties, configuration);
+        }
+        if (shouldUpdatePropertiesWithSaslConfig(configuration)) {
+            properties = updatePropertiesWithSaslConfiguration(properties, configuration);
+        }
+        if (shouldUpdateWithOauthConfig(configuration)) {
+            properties = updatePropertiesWithOauthConfig(properties, configuration);
+        }
+
+        return properties;
+    }
+
+    private static Properties updatePropertiesWithTlsConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
+        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL);
+        properties.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
+        properties.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, configuration.getSslTruststoreCertificate());
+
+        properties.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PEM");
+        properties.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, configuration.getSslKeystoreCertificateChain());
+        properties.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, configuration.getSslKeystoreKey());
+
+        return null;
+    }
+
+    private static Properties updatePropertiesWithSaslConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
+        SaslType saslType = SaslType.valueOf(configuration.getSaslMechanism());
+        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL);
+        properties.put(SaslConfigs.SASL_MECHANISM, saslType.getKafkaProperty());
+
+        String saslJaasConfig = configuration.getSaslJaasConfig();
+
+        if (saslJaasConfig == null) {
+            saslJaasConfig = saslType.equals(SaslType.PLAIN) ? PlainLoginModule.class.toString() : ScramLoginModule.class.toString();
+            saslJaasConfig += String.format(" required username=%s password=%s", configuration.getSaslUserName(), configuration.getSaslPassword());
+
+            if (saslType.equals(SaslType.SCRAM_SHA_512)) {
+                saslJaasConfig += "algorithm=SHA-512";
+            }
+
+            saslJaasConfig += ";";
+        }
+
+        properties.put(SaslConfigs.SASL_JAAS_CONFIG, saslJaasConfig);
+
+        return properties;
+    }
+
+    private static Properties updatePropertiesWithOauthConfig(Properties properties, KafkaClientsConfiguration configuration) {
+        properties.put(SaslConfigs.SASL_JAAS_CONFIG, OAuthBearerLoginModule.class + " required;");
+        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
+        properties.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+        if (!(configuration.getAdditionalConfig().containsKey(SaslConfigs.SASL_MECHANISM) && configuration.getAdditionalConfig().getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
+            properties.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, configuration.getSaslLoginCallbackClass());
+        }
+
+        return properties;
+    }
+
+    private static boolean shouldUpdatePropertiesWithTlsConfig(KafkaClientsConfiguration configuration) {
+        return configuration.getSslTruststoreCertificate() != null
+            && configuration.getSslKeystoreCertificateChain() != null
+            && configuration.getSslKeystoreKey() != null;
+    }
+
+    private static boolean shouldUpdatePropertiesWithSaslConfig(KafkaClientsConfiguration configuration) {
+        return configuration.getSaslMechanism() != null
+            && !configuration.getSaslMechanism().isEmpty()
+            && SaslType.getAllSaslTypes().contains(configuration.getSaslMechanism());
+    }
+
+    @SuppressWarnings({"BooleanExpressionComplexity", "checkstyle:UnnecessaryParentheses"})
+    private static boolean shouldUpdateWithOauthConfig(KafkaClientsConfiguration configuration) {
+        return (configuration.getOauthAccessToken() != null)
+            || (configuration.getOauthTokenEndpointUri() != null && configuration.getOauthClientId() != null && configuration.getOauthRefreshToken() != null)
+            || (configuration.getOauthTokenEndpointUri() != null && configuration.getOauthClientId() != null && configuration.getOauthClientSecret() != null);
+    }
+
+}

--- a/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
@@ -4,5 +4,107 @@
  */
 package io.strimzi.kafka;
 
-public class KafkaConsumerClient {
+import io.strimzi.common.ClientsInterface;
+import io.strimzi.common.configuration.Constants;
+import io.strimzi.common.configuration.kafka.KafkaConsumerConfiguration;
+import io.strimzi.common.properties.KafkaProperties;
+import io.strimzi.test.tracing.TracingUtil;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaConsumerClient implements ClientsInterface {
+    private static final Logger LOGGER = LogManager.getLogger(KafkaConsumerClient.class);
+    private final KafkaConsumerConfiguration configuration;
+    private final Properties properties;
+    private final KafkaConsumer consumer;
+    private int consumedMessages;
+    private final ScheduledExecutorService scheduledExecutor;
+
+    public KafkaConsumerClient(Map<String, String> configuration) {
+        this.configuration = new KafkaConsumerConfiguration(configuration);
+        this.properties = KafkaProperties.consumerProperties(this.configuration);
+        TracingUtil.initialize().addTracingPropsToConsumerConfig(properties);
+
+        this.consumer = new KafkaConsumer(this.properties);
+        this.consumedMessages = 0;
+        this.scheduledExecutor = Executors.newScheduledThreadPool(1, r -> new Thread(r, "kafka-consumer"));
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("Starting {} with configuration: \n{}", this.getClass().getName(), configuration.toString());
+
+        consumer.subscribe(Collections.singletonList(configuration.getTopicName()));
+
+        if (configuration.getDelayMs() == 0) {
+            scheduledExecutor.schedule(this::consumeMessages, Constants.DEFAULT_DELAY_MS, TimeUnit.MILLISECONDS);
+            scheduledExecutor.shutdown();
+        } else {
+            scheduledExecutor.scheduleWithFixedDelay(this::checkAndReceiveMessages, 0, configuration.getDelayMs(), TimeUnit.MILLISECONDS);
+        }
+
+        awaitCompletion();
+    }
+
+    @Override
+    public void awaitCompletion() {
+        try {
+            long timeoutForOperations = configuration.getMessageCount() * configuration.getDelayMs() + Constants.DEFAULT_TASK_COMPLETION_TIMEOUT;
+            scheduledExecutor.awaitTermination(timeoutForOperations, TimeUnit.MILLISECONDS);
+
+            if (consumedMessages >= configuration.getMessageCount()) {
+                LOGGER.info("All messages successfully received");
+            } else {
+                LOGGER.error("Unable to correctly receive all messages");
+                throw new RuntimeException("Failed to receive all messages");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error("Failed to wait for task completion due to: {}", e.getMessage());
+            e.printStackTrace();
+        } finally {
+            if (!scheduledExecutor.isShutdown()) {
+                scheduledExecutor.shutdownNow();
+            }
+        }
+    }
+
+    private void checkAndReceiveMessages() {
+        if (consumedMessages >= configuration.getMessageCount()) {
+            scheduledExecutor.shutdown();
+        } else {
+            this.consumeMessages();
+        }
+    }
+
+    public void consumeMessages() {
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+
+        for (ConsumerRecord<String, String> record : records) {
+            LOGGER.info("Received message:");
+            LOGGER.info("\tpartition: {}", record.partition());
+            LOGGER.info("\toffset: {}", record.offset());
+            LOGGER.info("\tvalue: {}", record.value());
+            if (record.headers() != null) {
+                LOGGER.info("\theaders: ");
+                for (Header header : record.headers()) {
+                    LOGGER.info("\t\tkey: {}, value: {}", header.key(), new String(header.value()));
+                }
+            }
+            consumedMessages++;
+        }
+
+        consumer.commitSync();
+    }
 }

--- a/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+public class KafkaConsumerClient {
+}

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -35,7 +35,7 @@ public class KafkaProducerClient implements ClientsInterface {
 
     public KafkaProducerClient(Map<String, String> configuration) {
         this.configuration = new KafkaProducerConfiguration(configuration);
-        this.properties =  KafkaProperties.producerProperties(this.configuration);
+        this.properties = KafkaProperties.producerProperties(this.configuration);
         TracingUtil.initialize().addTracingPropsToProducerConfig(properties);
 
         this.producer = new KafkaProducer<>(this.properties);

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+import io.strimzi.common.ClientsInterface;
+import io.strimzi.common.configuration.Constants;
+import io.strimzi.common.configuration.kafka.KafkaProducerConfiguration;
+import io.strimzi.common.properties.KafkaProperties;
+import io.strimzi.test.tracing.TracingUtil;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaProducerClient implements ClientsInterface {
+
+    private static final Logger LOGGER = LogManager.getLogger(KafkaProducerClient.class);
+    private final KafkaProducerConfiguration configuration;
+    private final Properties properties;
+    private final KafkaProducer producer;
+    private int messageIndex;
+    private int messageSuccessfullySent;
+    private final ScheduledExecutorService scheduledExecutor;
+
+    public KafkaProducerClient(Map<String, String> configuration) {
+        this.configuration = new KafkaProducerConfiguration(configuration);
+        this.properties =  KafkaProperties.producerProperties(this.configuration);
+        TracingUtil.initialize().addTracingPropsToProducerConfig(properties);
+
+        this.producer = new KafkaProducer<>(this.properties);
+        this.messageIndex = 0;
+        this.messageSuccessfullySent = 0;
+        this.scheduledExecutor = Executors.newScheduledThreadPool(1, r -> new Thread(r, "kafka-producer"));
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("Starting {} with configuration: \n{}", this.getClass().getName(), configuration.toString());
+
+        if (configuration.isTransactionalProducer()) {
+            LOGGER.info("Using transactional producer. Initializing the transactions.");
+            producer.initTransactions();
+        }
+
+        // in case we want to send all messages immediately, we have to schedule just one task
+        if (configuration.getDelayMs() == 0) {
+            scheduledExecutor.schedule(this::sendMessages, Constants.DEFAULT_DELAY_MS, TimeUnit.MILLISECONDS);
+            scheduledExecutor.shutdown();
+        } else {
+            scheduledExecutor.scheduleAtFixedRate(this::checkAndSendMessages, Constants.DEFAULT_DELAY_MS, configuration.getDelayMs(), TimeUnit.MILLISECONDS);
+        }
+
+        awaitCompletion();
+    }
+
+    @Override
+    public void awaitCompletion() {
+        try {
+            long timeoutForOperations = configuration.getMessageCount() * configuration.getDelayMs() + Constants.DEFAULT_TASK_COMPLETION_TIMEOUT;
+            scheduledExecutor.awaitTermination(timeoutForOperations, TimeUnit.MILLISECONDS);
+
+            if (messageSuccessfullySent == configuration.getMessageCount()) {
+                LOGGER.info("All messages successfully sent");
+            } else {
+                LOGGER.error("Unable to correctly send all messages");
+                throw new RuntimeException("Failed to send all messages");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.error("Failed to wait for task completion due to: {}", e.getMessage());
+            e.printStackTrace();
+        } finally {
+            if (!scheduledExecutor.isShutdown()) {
+                scheduledExecutor.shutdownNow();
+            }
+        }
+    }
+
+    public void checkAndSendMessages() {
+        if (messageIndex == configuration.getMessageCount()) {
+            scheduledExecutor.shutdown();
+        } else {
+            this.sendMessages();
+        }
+    }
+
+    public ProducerRecord generateMessage(int numOfMessage) {
+        return new ProducerRecord(configuration.getTopicName(), null, null, null,
+            "\"" + configuration.getMessage() + " - " + numOfMessage + "\"", configuration.getHeaders());
+    }
+
+    public List<ProducerRecord> generateMessages() {
+        List<ProducerRecord> records = new ArrayList<>();
+        for (int i = 0; i < configuration.getMessageCount(); i++) {
+            records.add(generateMessage(i));
+        }
+
+        return records;
+    }
+
+    public void sendMessages() {
+        List<ProducerRecord> records = configuration.getDelayMs() == 0 ? generateMessages() : Collections.singletonList(generateMessage(messageIndex));
+        messageIndex += records.size();
+
+        int currentMsgIndex = configuration.getDelayMs() == 0 ? 0 : messageIndex;
+
+        for (ProducerRecord record : records) {
+
+            if (configuration.isTransactionalProducer() && currentMsgIndex % configuration.getMessagesPerTransaction() == 0) {
+                LOGGER.info("Beginning new transaction. Messages sent: {}", currentMsgIndex);
+                producer.beginTransaction();
+            }
+            LOGGER.info("Sending message: {}", record.toString());
+
+            try {
+                producer.send(record).get();
+                messageSuccessfullySent++;
+            } catch (Exception e) {
+                LOGGER.error("Failed to send messages: {} due to: \n{}", record.toString(), e.getMessage());
+            }
+
+            if (configuration.isTransactionalProducer() && (currentMsgIndex + 1) % configuration.getMessagesPerTransaction() == 0) {
+                LOGGER.info("Committing the transaction. Messages sent: {}", currentMsgIndex);
+                producer.commitTransaction();
+            }
+        }
+    }
+}

--- a/clients/src/main/java/io/strimzi/kafka/KafkaStreamsClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaStreamsClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka;
+
+import io.strimzi.common.ClientsInterface;
+import io.strimzi.common.configuration.kafka.KafkaStreamsConfiguration;
+import io.strimzi.common.properties.KafkaProperties;
+import io.strimzi.test.tracing.TracingUtil;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Properties;
+
+public class KafkaStreamsClient implements ClientsInterface {
+    private static final Logger LOGGER = LogManager.getLogger(KafkaStreamsClient.class);
+    private final KafkaStreamsConfiguration configuration;
+    private final Properties properties;
+
+    public KafkaStreamsClient(Map<String, String> configuration) {
+        this.configuration = new KafkaStreamsConfiguration(configuration);
+        this.properties = KafkaProperties.streamsProperties(this.configuration);
+    }
+
+    @Override
+    public void run() {
+        LOGGER.info("Starting {} with configuration: \n{}", this.getClass().getName(), this.configuration.toString());
+
+        StreamsBuilder builder = new StreamsBuilder();
+
+        builder.stream(configuration.getSourceTopic(), Consumed.with(Serdes.String(), Serdes.String()))
+            .mapValues(value -> {
+                StringBuilder sb = new StringBuilder();
+                sb.append(value);
+                return sb.reverse().toString();
+            })
+            .to(configuration.getTargetTopic(), Produced.with(Serdes.String(), Serdes.String()));
+
+        Topology topology = builder.build();
+
+        KafkaStreams streams = TracingUtil.initialize().getStreamsWithTracing(topology, this.properties);
+
+        streams.start();
+    }
+
+    @Override
+    public void awaitCompletion() {
+
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaClientsConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaClientsConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import io.strimzi.common.SaslType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static io.strimzi.common.configuration.Constants.ADDITIONAL_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.CA_CRT_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_DELAY_MS;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGES_COUNT;
+import static io.strimzi.common.configuration.Constants.DELAY_MS_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGE_COUNT_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_ACCESS_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_SECRET_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_REFRESH_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_JAAS_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_MECHANISM_ENV;
+import static io.strimzi.common.configuration.Constants.USER_CERT_ENV;
+import static io.strimzi.common.configuration.Constants.USER_KEY_ENV;
+import static io.strimzi.common.configuration.Constants.USER_NAME_ENV;
+import static io.strimzi.common.configuration.Constants.USER_PASSWORD_ENV;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class KafkaClientsConfigurationTest {
+
+    @Test
+    void testDefaultConfiguration() {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        assertThat(kafkaClientsConfiguration.getDelayMs(), is(DEFAULT_DELAY_MS));
+        assertThat(kafkaClientsConfiguration.getMessageCount(), is(DEFAULT_MESSAGES_COUNT));
+        assertThat(kafkaClientsConfiguration.getAdditionalConfig(), is(new Properties()));
+    }
+
+    @Test
+    void testCustomConfiguration() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        String accessToken = "access-token";
+        String oauthTokenEndpointUri = "localhost:9090/path/to/token";
+        String oauthClientId = "client-id";
+        String refreshToken = "refresh token";
+        String clientSecret = "client secret";
+        String userName = "arnost";
+        String userPassword = "completely-top-secret";
+        String saslJaasConfig = "my-sasl-config";
+        String sslTruststoreCert = "my-cert";
+        String sslKeystoreCert = "my-user-cert";
+        String sslKeystoreKey = "my-user-key";
+        String additionalProperties = "my-key=my-value";
+        int messageCount = 678;
+        long delayMs = 68899;
+
+        Properties expectedAdditionalProps = new Properties();
+        expectedAdditionalProps.put("my-key", "my-value");
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(SASL_MECHANISM_ENV, SaslType.SCRAM_SHA_512.getName());
+        configuration.put(USER_NAME_ENV, userName);
+        configuration.put(USER_PASSWORD_ENV, userPassword);
+        configuration.put(SASL_JAAS_CONFIG_ENV, saslJaasConfig);
+        configuration.put(OAUTH_ACCESS_TOKEN_ENV, accessToken);
+        configuration.put(OAUTH_TOKEN_ENDPOINT_URI_ENV, oauthTokenEndpointUri);
+        configuration.put(OAUTH_CLIENT_ID_ENV, oauthClientId);
+        configuration.put(OAUTH_REFRESH_TOKEN_ENV, refreshToken);
+        configuration.put(OAUTH_CLIENT_SECRET_ENV, clientSecret);
+        configuration.put(CA_CRT_ENV, sslTruststoreCert);
+        configuration.put(USER_CERT_ENV, sslKeystoreCert);
+        configuration.put(USER_KEY_ENV, sslKeystoreKey);
+        configuration.put(ADDITIONAL_CONFIG_ENV, additionalProperties);
+        configuration.put(MESSAGE_COUNT_ENV, String.valueOf(messageCount));
+        configuration.put(DELAY_MS_ENV, String.valueOf(delayMs));
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        assertThat(kafkaClientsConfiguration.getBootstrapServers(), is(bootstrapServer));
+        assertThat(kafkaClientsConfiguration.getSaslMechanism(), is(SaslType.SCRAM_SHA_512.getName()));
+        assertThat(kafkaClientsConfiguration.getSaslUserName(), is(userName));
+        assertThat(kafkaClientsConfiguration.getSaslPassword(), is(userPassword));
+        assertThat(kafkaClientsConfiguration.getSaslJaasConfig(), is(saslJaasConfig));
+        assertThat(kafkaClientsConfiguration.getOauthAccessToken(), is(accessToken));
+        assertThat(kafkaClientsConfiguration.getOauthTokenEndpointUri(), is(oauthTokenEndpointUri));
+        assertThat(kafkaClientsConfiguration.getOauthClientId(), is(oauthClientId));
+        assertThat(kafkaClientsConfiguration.getOauthRefreshToken(), is(refreshToken));
+        assertThat(kafkaClientsConfiguration.getOauthClientSecret(), is(clientSecret));
+        assertThat(kafkaClientsConfiguration.getSslTruststoreCertificate(), is(sslTruststoreCert));
+        assertThat(kafkaClientsConfiguration.getSslKeystoreCertificateChain(), is(sslKeystoreCert));
+        assertThat(kafkaClientsConfiguration.getSslKeystoreKey(), is(sslKeystoreKey));
+        assertThat(kafkaClientsConfiguration.getAdditionalConfig(), is(expectedAdditionalProps));
+        assertThat(kafkaClientsConfiguration.getMessageCount(), is(messageCount));
+        assertThat(kafkaClientsConfiguration.getDelayMs(), is(delayMs));
+    }
+
+    @Test
+    void testInvalidConfiguration() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        String delayMs = "this will not work";
+        String messageCount = "this too";
+        int additionalProps = 25;
+
+        Map<String, String> configuration = new HashMap<>();
+
+        assertThrows(RuntimeException.class, () -> new KafkaClientsConfiguration(configuration));
+
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(DELAY_MS_ENV, delayMs);
+        configuration.put(MESSAGE_COUNT_ENV, messageCount);
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        assertThat(kafkaClientsConfiguration.getDelayMs(), is(DEFAULT_DELAY_MS));
+        assertThat(kafkaClientsConfiguration.getMessageCount(), is(DEFAULT_MESSAGES_COUNT));
+
+        configuration.put(ADDITIONAL_CONFIG_ENV, String.valueOf(additionalProps));
+
+        assertThrows(RuntimeException.class, () -> new KafkaClientsConfiguration(configuration));
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaConsumerConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.CLIENT_RACK_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_CLIENT_ID;
+import static io.strimzi.common.configuration.Constants.DEFAULT_GROUP_ID;
+import static io.strimzi.common.configuration.Constants.GROUP_ID_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class KafkaConsumerConfigurationTest {
+
+    @Test
+    void testDefaultConfiguration() {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(TOPIC_ENV, "my-topic");
+
+        KafkaConsumerConfiguration kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
+
+        assertThat(kafkaConsumerConfiguration.getClientRack(), nullValue());
+        assertThat(kafkaConsumerConfiguration.getClientId(), is(DEFAULT_CLIENT_ID));
+        assertThat(kafkaConsumerConfiguration.getGroupId(), is(DEFAULT_GROUP_ID));
+    }
+
+    @Test
+    void testCustomConfiguration() {
+        String clientId = "random-client-id";
+        String groupId = "random-group-id";
+        String clientRack = "rack-0";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(TOPIC_ENV, "my-topic");
+        configuration.put(CLIENT_ID_ENV, clientId);
+        configuration.put(GROUP_ID_ENV, groupId);
+        configuration.put(CLIENT_RACK_ENV, clientRack);
+
+        KafkaConsumerConfiguration kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
+
+        assertThat(kafkaConsumerConfiguration.getClientRack(), is(clientRack));
+        assertThat(kafkaConsumerConfiguration.getClientId(), is(clientId));
+        assertThat(kafkaConsumerConfiguration.getGroupId(), is(groupId));
+    }
+
+    @Test
+    void testInvalidConfiguration() {
+        String topicName = "my-topic";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+
+        assertThrows(InvalidParameterException.class, () -> new KafkaConsumerConfiguration(configuration));
+
+        configuration.put(TOPIC_ENV, topicName);
+
+        KafkaConsumerConfiguration kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
+
+        assertThat(kafkaConsumerConfiguration.getTopicName(), is(topicName));
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Test;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.strimzi.common.configuration.Constants.ADDITIONAL_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGE;
+import static io.strimzi.common.configuration.Constants.DEFAULT_MESSAGES_PER_TRANSACTION;
+import static io.strimzi.common.configuration.Constants.DEFAULT_PRODUCER_ACKS;
+import static io.strimzi.common.configuration.Constants.HEADERS_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGES_PER_TRANSACTION_ENV;
+import static io.strimzi.common.configuration.Constants.MESSAGE_ENV;
+import static io.strimzi.common.configuration.Constants.PRODUCER_ACKS_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class KafkaProducerConfigurationTest {
+
+    @Test
+    void testDefaultConfiguration() {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(TOPIC_ENV, "my-topic");
+
+        KafkaProducerConfiguration kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
+
+        assertThat(kafkaProducerConfiguration.getAcks(), is(DEFAULT_PRODUCER_ACKS));
+        assertThat(kafkaProducerConfiguration.getHeaders(), nullValue());
+        assertThat(kafkaProducerConfiguration.getMessage(), is(DEFAULT_MESSAGE));
+        assertThat(kafkaProducerConfiguration.getMessagesPerTransaction(), is(DEFAULT_MESSAGES_PER_TRANSACTION));
+        assertThat(kafkaProducerConfiguration.isTransactionalProducer(), is(false));
+        assertThat(kafkaProducerConfiguration.getTopicName(), is("my-topic"));
+    }
+
+    @Test
+    void testCustomConfiguration() {
+        String bootstrapServer = "randomized-my-cluster-kafka:9092";
+        String topicName = "epic-topic";
+        String acks = "0";
+        String headers = "header_key_one=header_value_one, header_key_two=header_value_two";
+        String message = "Muhehe";
+        int messagesPerTransaction = 125;
+        String additionalConfig = ProducerConfig.TRANSACTIONAL_ID_CONFIG + " = my-id";
+
+        List<Header> expectedHeadersList = new ArrayList<>();
+        expectedHeadersList.add(new RecordHeader("header_key_one", "header_value_one".getBytes()));
+        expectedHeadersList.add(new RecordHeader("header_key_two", "header_value_two".getBytes()));
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(TOPIC_ENV, topicName);
+        configuration.put(PRODUCER_ACKS_ENV, acks);
+        configuration.put(HEADERS_ENV, headers);
+        configuration.put(MESSAGE_ENV, message);
+        configuration.put(MESSAGES_PER_TRANSACTION_ENV, String.valueOf(messagesPerTransaction));
+        configuration.put(ADDITIONAL_CONFIG_ENV, additionalConfig);
+
+        KafkaProducerConfiguration kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
+
+        assertThat(kafkaProducerConfiguration.getAcks(), is(acks));
+        assertThat(kafkaProducerConfiguration.getHeaders(), is(expectedHeadersList));
+        assertThat(kafkaProducerConfiguration.getMessage(), is(message));
+        assertThat(kafkaProducerConfiguration.getMessagesPerTransaction(), is(messagesPerTransaction));
+        assertThat(kafkaProducerConfiguration.isTransactionalProducer(), is(true));
+        assertThat(kafkaProducerConfiguration.getTopicName(), is(topicName));
+        assertThat(kafkaProducerConfiguration.getBootstrapServers(), is(bootstrapServer));
+    }
+
+    @Test
+    void testInvalidConfiguration() {
+        int headers = 25;
+        String messagesPerTransaction = "this will not work";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(MESSAGES_PER_TRANSACTION_ENV, messagesPerTransaction);
+
+        assertThrows(InvalidParameterException.class, () -> new KafkaProducerConfiguration(configuration));
+
+        configuration.put(TOPIC_ENV, "my-topic");
+
+        KafkaProducerConfiguration kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
+
+        assertThat(kafkaProducerConfiguration.getMessagesPerTransaction(), is(DEFAULT_MESSAGES_PER_TRANSACTION));
+
+        configuration.put(HEADERS_ENV, String.valueOf(headers));
+
+        assertThrows(RuntimeException.class, () -> new KafkaProducerConfiguration(configuration));
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/common/configuration/kafka/KafkaStreamsConfigurationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.configuration.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.strimzi.common.configuration.Constants.APPLICATION_ID_ENV;
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.COMMIT_INTERVAL_MS_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_COMMIT_INTERVAL_MS;
+import static io.strimzi.common.configuration.Constants.SOURCE_TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.TARGET_TOPIC_ENV;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KafkaStreamsConfigurationTest {
+    @Test
+    void testDefaultConfiguration() {
+        // by default all Streams config have to be set
+        String bootstrapServer = "target-my-topic";
+        String sourceTopic = "my-cluster-kafka:9092";
+        String targetTopic = "source-my-topic";
+        String appId = "my-app-0";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        assertThrows(InvalidParameterException.class, () -> new KafkaStreamsConfiguration(configuration));
+
+        configuration.put(APPLICATION_ID_ENV, appId);
+
+        assertThrows(InvalidParameterException.class, () -> new KafkaStreamsConfiguration(configuration));
+
+        configuration.put(SOURCE_TOPIC_ENV, sourceTopic);
+
+        assertThrows(InvalidParameterException.class, () -> new KafkaStreamsConfiguration(configuration));
+
+        configuration.put(TARGET_TOPIC_ENV, targetTopic);
+
+        KafkaStreamsConfiguration kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
+
+        assertThat(kafkaStreamsConfiguration.getApplicationId(), is(appId));
+        assertThat(kafkaStreamsConfiguration.getSourceTopic(), is(sourceTopic));
+        assertThat(kafkaStreamsConfiguration.getTargetTopic(), is(targetTopic));
+        assertThat(kafkaStreamsConfiguration.getCommitIntervalMs(), is(DEFAULT_COMMIT_INTERVAL_MS));
+    }
+
+    @Test
+    void testCustomConfiguration() {
+        String appId = "absolute-id";
+        String sourceTopic = "second-cluster-kafka:9093";
+        String targetTopic = "arnost-topic";
+        String bootstrapServer = "alice-topic";
+        long commitIntervalMs = 800000L;
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(SOURCE_TOPIC_ENV, sourceTopic);
+        configuration.put(TARGET_TOPIC_ENV, targetTopic);
+        configuration.put(APPLICATION_ID_ENV, appId);
+        configuration.put(COMMIT_INTERVAL_MS_ENV, String.valueOf(commitIntervalMs));
+
+        KafkaStreamsConfiguration kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
+
+        assertThat(kafkaStreamsConfiguration.getApplicationId(), is(appId));
+        assertThat(kafkaStreamsConfiguration.getSourceTopic(), is(sourceTopic));
+        assertThat(kafkaStreamsConfiguration.getTargetTopic(), is(targetTopic));
+        assertThat(kafkaStreamsConfiguration.getCommitIntervalMs(), is(commitIntervalMs));
+    }
+
+    @Test
+    void testInvalidConfiguration() {
+        String appId = "absolute-id";
+        String sourceTopic = "second-cluster-kafka:9093";
+        String targetTopic = "arnost-topic";
+        String bootstrapServer = "alice-topic";
+        String commitIntervalMs = "this is only thing which is wrong";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(SOURCE_TOPIC_ENV, sourceTopic);
+        configuration.put(TARGET_TOPIC_ENV, targetTopic);
+        configuration.put(APPLICATION_ID_ENV, appId);
+        configuration.put(COMMIT_INTERVAL_MS_ENV, commitIntervalMs);
+
+        KafkaStreamsConfiguration kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
+
+        assertThat(kafkaStreamsConfiguration.getCommitIntervalMs(), is(DEFAULT_COMMIT_INTERVAL_MS));
+    }
+}

--- a/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
+++ b/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common.properties;
+
+import io.strimzi.common.SaslType;
+import io.strimzi.common.configuration.Constants;
+import io.strimzi.common.configuration.kafka.KafkaClientsConfiguration;
+import io.strimzi.common.configuration.kafka.KafkaConsumerConfiguration;
+import io.strimzi.common.configuration.kafka.KafkaProducerConfiguration;
+
+import static io.strimzi.common.configuration.Constants.ADDITIONAL_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.APPLICATION_ID_ENV;
+import static io.strimzi.common.configuration.Constants.BOOTSTRAP_SERVERS_ENV;
+import static io.strimzi.common.configuration.Constants.CA_CRT_ENV;
+import static io.strimzi.common.configuration.Constants.CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.CLIENT_RACK_ENV;
+import static io.strimzi.common.configuration.Constants.COMMIT_INTERVAL_MS_ENV;
+import static io.strimzi.common.configuration.Constants.DEFAULT_CLIENT_ID;
+import static io.strimzi.common.configuration.Constants.DEFAULT_COMMIT_INTERVAL_MS;
+import static io.strimzi.common.configuration.Constants.DEFAULT_GROUP_ID;
+import static io.strimzi.common.configuration.Constants.DEFAULT_PRODUCER_ACKS;
+import static io.strimzi.common.configuration.Constants.GROUP_ID_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_ACCESS_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_ID_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_CLIENT_SECRET_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_REFRESH_TOKEN_ENV;
+import static io.strimzi.common.configuration.Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
+import static io.strimzi.common.configuration.Constants.PRODUCER_ACKS_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_JAAS_CONFIG_ENV;
+import static io.strimzi.common.configuration.Constants.SASL_MECHANISM_ENV;
+import static io.strimzi.common.configuration.Constants.SOURCE_TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.TARGET_TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.TOPIC_ENV;
+import static io.strimzi.common.configuration.Constants.USER_CERT_ENV;
+import static io.strimzi.common.configuration.Constants.USER_KEY_ENV;
+import static io.strimzi.common.configuration.Constants.USER_NAME_ENV;
+import static io.strimzi.common.configuration.Constants.USER_PASSWORD_ENV;
+import static org.hamcrest.CoreMatchers.is;
+
+import io.strimzi.common.configuration.kafka.KafkaStreamsConfiguration;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramLoginModule;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KafkaPropertiesTest {
+
+    @Test
+    void testShouldConfigureOauthCheck() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that empty properties will not configure Oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.OAUTH_ACCESS_TOKEN_ENV, "access-token");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties with just Oauth access token will configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(true));
+
+        configuration.remove(Constants.OAUTH_ACCESS_TOKEN_ENV);
+        configuration.put(Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV, "localhost:9090/path/to/token");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties without Oauth access token and just with Oauth token endpoint uri will not configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.OAUTH_CLIENT_ID_ENV, "client-id");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties without Oauth access token and just with Oauth token endpoint uri + client id will not configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.OAUTH_REFRESH_TOKEN_ENV, "refresh token");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties without Oauth access token and with Oauth token endpoint uri + client id + refresh token will configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(true));
+
+        configuration.remove(Constants.OAUTH_REFRESH_TOKEN_ENV);
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties without Oauth access token and just with Oauth token endpoint uri + client id will not configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.OAUTH_CLIENT_SECRET_ENV, "client secret");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties without Oauth access token and with Oauth token endpoint uri + client id + client secret will configure oauth
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithOauthConfig(kafkaClientsConfiguration), is(true));
+    }
+
+    @Test
+    void testShouldConfigureTlsCheck() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that empty properties will not configure TLS
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithTlsConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.CA_CRT_ENV, "my-ca-cert");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties with just CA cert will not configure TLS
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithTlsConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.USER_CERT_ENV, "my-user-cert");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties with CA cert and user cert will not configure TLS
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithTlsConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.USER_KEY_ENV, "my-user-key");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that properties with CA cert, user cert and user key will configure TLS
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithTlsConfig(kafkaClientsConfiguration), is(true));
+    }
+
+    @Test
+    void testShouldConfigureSaslCheck() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that empty properties will not configure SASL
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithSaslConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.SASL_MECHANISM_ENV, "");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that empty SASL mechanism env will not configure SASL
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithSaslConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.SASL_MECHANISM_ENV, "random");
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that wrong value in SASL mechanism env will not configure SASL
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithSaslConfig(kafkaClientsConfiguration), is(false));
+
+        configuration.put(Constants.SASL_MECHANISM_ENV, SaslType.SCRAM_SHA_256.getName());
+
+        kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check that with correct SASL mechanism in the env it will configure SASL
+        assertThat(KafkaProperties.shouldUpdatePropertiesWithSaslConfig(kafkaClientsConfiguration), is(true));
+    }
+
+    @Test
+    void testConfigureProducerProperties() {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(TOPIC_ENV, "my-topic");
+
+        KafkaProducerConfiguration kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
+
+        // check default properties
+        Properties producerProperties = KafkaProperties.producerProperties(kafkaProducerConfiguration);
+
+        assertThat(producerProperties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG), is(StringSerializer.class.getName()));
+        assertThat(producerProperties.getProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG), is(StringSerializer.class.getName()));
+        assertThat(producerProperties.getProperty(ProducerConfig.ACKS_CONFIG), is(DEFAULT_PRODUCER_ACKS));
+
+        String producerAcks = "0";
+        configuration.put(PRODUCER_ACKS_ENV, producerAcks);
+
+        kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
+        producerProperties = KafkaProperties.producerProperties(kafkaProducerConfiguration);
+
+        // check custom properties
+        assertThat(producerProperties.getProperty(ProducerConfig.ACKS_CONFIG), is(producerAcks));
+    }
+
+    @Test
+    void testConfigureConsumerProperties() {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(TOPIC_ENV, "my-topic");
+
+        KafkaConsumerConfiguration kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
+
+        // check default properties
+        Properties consumerProperties = KafkaProperties.consumerProperties(kafkaConsumerConfiguration);
+
+        assertThat(consumerProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), is(StringDeserializer.class.getName()));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), is(StringDeserializer.class.getName()));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG), is(DEFAULT_CLIENT_ID));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG), is(DEFAULT_GROUP_ID));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG), nullValue());
+        assertThat(consumerProperties.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), is("earliest"));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG), is("false"));
+
+        String clientId = "random-client-id";
+        String groupId = "random-group-id";
+        String clientRack = "rack-0";
+
+        configuration.put(CLIENT_ID_ENV, clientId);
+        configuration.put(GROUP_ID_ENV, groupId);
+        configuration.put(CLIENT_RACK_ENV, clientRack);
+
+        kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
+
+        consumerProperties = KafkaProperties.consumerProperties(kafkaConsumerConfiguration);
+
+        // check custom properties
+        assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG), is(clientId));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG), is(groupId));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG), is(clientRack));
+    }
+
+    @Test
+    void testConfigureStreamsProperties() {
+        String appId = "my-app-0";
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, "my-cluster-kafka:9092");
+        configuration.put(SOURCE_TOPIC_ENV, "source-my-topic");
+        configuration.put(TARGET_TOPIC_ENV, "target-my-topic");
+        configuration.put(APPLICATION_ID_ENV, appId);
+
+        KafkaStreamsConfiguration kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
+
+        // check default properties
+        Properties streamsProperties = KafkaProperties.streamsProperties(kafkaStreamsConfiguration);
+
+        assertThat(streamsProperties.getProperty(StreamsConfig.APPLICATION_ID_CONFIG), is(appId));
+        assertThat(streamsProperties.get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), is(DEFAULT_COMMIT_INTERVAL_MS));
+        assertThat(streamsProperties.get(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG).toString(), is(Serdes.String().getClass().toString()));
+        assertThat(streamsProperties.get(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG).toString(), is(Serdes.String().getClass().toString()));
+
+        long commitInterval = 7000L;
+        configuration.put(COMMIT_INTERVAL_MS_ENV, String.valueOf(commitInterval));
+
+        kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
+
+        streamsProperties = KafkaProperties.streamsProperties(kafkaStreamsConfiguration);
+
+        // check custom properties
+        assertThat(streamsProperties.get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), is(commitInterval));
+    }
+
+    @Test
+    void testConfigureCommonProperties() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        KafkaClientsConfiguration kafkaClientsConfiguration = new KafkaClientsConfiguration(configuration);
+
+        // check properties properties
+        Properties commonProperties = KafkaProperties.clientProperties(kafkaClientsConfiguration);
+
+        assertThat(commonProperties.get("config.providers"), is("secrets,configmaps"));
+        assertThat(commonProperties.get("config.providers.secrets.class"), is("io.strimzi.kafka.KubernetesSecretConfigProvider"));
+        assertThat(commonProperties.get("config.providers.configmaps.class"), is("io.strimzi.kafka.KubernetesConfigMapConfigProvider"));
+        assertThat(commonProperties.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), is(bootstrapServer));
+    }
+
+    @Test
+    void testUpdatePropertiesWithTlsConfiguration() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        String sslTruststoreCert = "my-cert";
+        String sslKeystoreCert = "my-user-cert";
+        String sslKeystoreKey = "my-user-key";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(CA_CRT_ENV, sslTruststoreCert);
+        configuration.put(USER_CERT_ENV, sslKeystoreCert);
+        configuration.put(USER_KEY_ENV, sslKeystoreKey);
+
+        KafkaClientsConfiguration clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        Properties properties = new Properties();
+        properties = KafkaProperties.updatePropertiesWithTlsConfiguration(properties, clientsConfiguration);
+
+        assertThat(properties.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), is(SecurityProtocol.SSL));
+        assertThat(properties.getProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), is("PEM"));
+        assertThat(properties.getProperty(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG), is(sslTruststoreCert));
+
+        assertThat(properties.getProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG), is("PEM"));
+        assertThat(properties.getProperty(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG), is(sslKeystoreCert));
+        assertThat(properties.getProperty(SslConfigs.SSL_KEYSTORE_KEY_CONFIG), is(sslKeystoreKey));
+    }
+
+    @Test
+    void testUpdatePropertiesWithSaslConfiguration() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        String saslJaasConfig = "my-sasl-config";
+        String userName = "arnost";
+        String userPassword = "completely-top-secret";
+        String expectedJaas = ScramLoginModule.class + String.format(" required username=%s password=%s algorithm=SHA-512;", userName, userPassword);
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+        configuration.put(SASL_MECHANISM_ENV, SaslType.SCRAM_SHA_512.getName());
+        configuration.put(SASL_JAAS_CONFIG_ENV, saslJaasConfig);
+
+        KafkaClientsConfiguration clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        Properties properties = new Properties();
+        properties = KafkaProperties.updatePropertiesWithSaslConfiguration(properties, clientsConfiguration);
+
+        assertThat(properties.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), is(SecurityProtocol.SASL_SSL));
+        assertThat(properties.getProperty(SaslConfigs.SASL_MECHANISM), is(SaslType.SCRAM_SHA_512.getKafkaProperty()));
+        assertThat(properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(saslJaasConfig));
+
+        configuration.remove(SASL_JAAS_CONFIG_ENV);
+        configuration.put(USER_NAME_ENV, userName);
+        configuration.put(USER_PASSWORD_ENV, userPassword);
+
+        clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        properties = KafkaProperties.updatePropertiesWithSaslConfiguration(properties, clientsConfiguration);
+
+        assertThat(properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(expectedJaas));
+
+        configuration.put(SASL_MECHANISM_ENV, SaslType.SCRAM_SHA_256.getName());
+
+        clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        properties = KafkaProperties.updatePropertiesWithSaslConfiguration(properties, clientsConfiguration);
+
+        expectedJaas = expectedJaas.replace(" algorithm=SHA-512", "");
+
+        assertThat(properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(expectedJaas));
+
+        configuration.put(SASL_MECHANISM_ENV, SaslType.PLAIN.getName());
+
+        clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        properties = KafkaProperties.updatePropertiesWithSaslConfiguration(properties, clientsConfiguration);
+
+        expectedJaas = expectedJaas.replace(ScramLoginModule.class.toString(), PlainLoginModule.class.toString());
+
+        assertThat(properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(expectedJaas));
+    }
+
+    @Test
+    void testUpdatePropertiesWithOauthConfig() {
+        String bootstrapServer = "my-cluster-kafka:9092";
+        String accessToken = "access-token";
+        String oauthTokenEndpointUri = "localhost:9090/path/to/token";
+        String oauthClientId = "client-id";
+        String refreshToken = "refresh token";
+        String clientSecret = "client secret";
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(OAUTH_ACCESS_TOKEN_ENV, accessToken);
+        configuration.put(OAUTH_TOKEN_ENDPOINT_URI_ENV, oauthTokenEndpointUri);
+        configuration.put(OAUTH_CLIENT_ID_ENV, oauthClientId);
+        configuration.put(OAUTH_REFRESH_TOKEN_ENV, refreshToken);
+        configuration.put(OAUTH_CLIENT_SECRET_ENV, clientSecret);
+        configuration.put(BOOTSTRAP_SERVERS_ENV, bootstrapServer);
+
+        KafkaClientsConfiguration clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        Properties properties = new Properties();
+        properties = KafkaProperties.updatePropertiesWithOauthConfig(properties, clientsConfiguration);
+
+        assertThat(properties.getProperty(SaslConfigs.SASL_JAAS_CONFIG), is(OAuthBearerLoginModule.class + " required;"));
+        assertThat(properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), is("SASL_PLAINTEXT"));
+        assertThat(properties.getProperty(SaslConfigs.SASL_MECHANISM), is("OAUTHBEARER"));
+        assertThat(properties.getProperty(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS), is("io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"));
+
+        configuration.put(ADDITIONAL_CONFIG_ENV, CommonClientConfigs.SECURITY_PROTOCOL_CONFIG + "= SSL\n" + SaslConfigs.SASL_MECHANISM + "= PLAIN");
+
+        clientsConfiguration = new KafkaClientsConfiguration(configuration);
+        properties = new Properties();
+        properties = KafkaProperties.updatePropertiesWithOauthConfig(properties, clientsConfiguration);
+
+        assertThat(properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), is("SASL_PLAINTEXT"));
+        assertThat(properties.getProperty(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS), nullValue());
+    }
+}


### PR DESCRIPTION
This PR refactors all Kafka clients into new `clients` module, with changes to the overall logic.

Also, it merges the Kafka clients configuration (properties) into one file.
As part of this PR, unit tests are added.

Closes #47 