### PR TITLE
Fix push containers

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -59,7 +59,7 @@ jobs:
           ARCHITECTURES: 'amd64 s390x ppc64le arm64'
       - script: |
             docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
-            make docker_push docker_amend_manifest docker_push_manifest
+            make docker_push docker_amend_manifest docker_push_manifest --directory=docker-images/
         displayName: "Push containers"
         env:
           DOCKER_REGISTRY: "quay.io"


### PR DESCRIPTION
In #56 I added a new build system, but I forgot to add the `--directory=docker-images/` into the make command inside the `Push containers` stage.

This PR fixes it.