### PR TITLE
Fix race condition where the client will wait for acks, but all messages will be sent

### DIFF
--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -133,15 +133,12 @@ public class KafkaProducerClient implements ClientsInterface {
             }
             LOGGER.info("Sending message: {}", record.toString());
 
-            // we are increasing the messageIndex on two places to remove race conditions with the acknowledgement
-            // where the messageIndex can be on the desired number of messages and all can be successful, but the
-            // messageSuccessfullySent will not have correct number (as it will wait for ack and it will not be increased) and the client will then fail
             try {
                 producer.send(record).get();
-                messageIndex++;
                 messageSuccessfullySent++;
             } catch (Exception e) {
                 LOGGER.error("Failed to send messages: {} due to: \n{}", record.toString(), e.getMessage());
+            } finally {
                 messageIndex++;
             }
 


### PR DESCRIPTION
This PR fixes a small bug inside the KafkaProducer, where we are increasing the number of `messageSuccessfullySent` only after the `producer.send(record).get();` - when we set `acks=all`, we are waiting for the acknowledgment coming back, but in some cases, we can have the `messageIndex` on the desired number of messages, but `messageSuccessfullySent` on much lower number, because for other messages we didn't received the ack back.