### PR TITLE
Different approach for sending messages when delay is set to 0

### DIFF
--- a/clients/src/main/java/io/strimzi/common/ClientsInterface.java
+++ b/clients/src/main/java/io/strimzi/common/ClientsInterface.java
@@ -7,4 +7,5 @@ package io.strimzi.common;
 public interface ClientsInterface {
     void run();
     void awaitCompletion();
+    void checkFinalState();
 }

--- a/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
@@ -55,6 +55,7 @@ public class KafkaConsumerClient implements ClientsInterface {
         scheduledExecutor.scheduleWithFixedDelay(this::checkAndReceiveMessages, 0, delayMs, TimeUnit.MILLISECONDS);
 
         awaitCompletion();
+        checkFinalState();
     }
 
     @Override
@@ -62,13 +63,6 @@ public class KafkaConsumerClient implements ClientsInterface {
         try {
             countDownLatch.await();
             scheduledExecutor.awaitTermination(Constants.DEFAULT_TASK_COMPLETION_TIMEOUT, TimeUnit.MILLISECONDS);
-
-            if (consumedMessages >= configuration.getMessageCount()) {
-                LOGGER.info("All messages successfully received");
-            } else {
-                LOGGER.error("Unable to correctly receive all messages");
-                throw new RuntimeException("Failed to receive all messages");
-            }
         } catch (InterruptedException e) {
             LOGGER.error("Failed to wait for task completion due to: {}", e.getMessage());
             e.printStackTrace();
@@ -79,8 +73,19 @@ public class KafkaConsumerClient implements ClientsInterface {
         }
     }
 
+    @Override
+    public void checkFinalState() {
+        if (consumedMessages >= configuration.getMessageCount()) {
+            LOGGER.info("All messages successfully received");
+        } else {
+            LOGGER.error("Unable to correctly receive all messages");
+            throw new RuntimeException("Failed to receive all messages");
+        }
+    }
+
     private void checkAndReceiveMessages() {
         if (consumedMessages >= configuration.getMessageCount()) {
+            LOGGER.info("Shutting down the executor");
             scheduledExecutor.shutdown();
             countDownLatch.countDown();
         } else {

--- a/clients/src/main/java/io/strimzi/kafka/KafkaStreamsClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaStreamsClient.java
@@ -55,4 +55,9 @@ public class KafkaStreamsClient implements ClientsInterface {
     public void awaitCompletion() {
 
     }
+
+    @Override
+    public void checkFinalState() {
+
+    }
 }


### PR DESCRIPTION
This PR removes the `scheduledExecutor.schedule()` method from places, where we are using the delay set to 0.
Also, for checking the messages I added another method - `checkFinalState` - that will verify send/received messages at the end of the process.

With `schedule()` there were issues with threading, were we were still sending the messages, but the process was already ended and the check for send/received messages has failed.