### PR TITLE
Update AZP agent's image to Ubuntu 22.04

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         'java-17':
-          image: 'Ubuntu-18.04'
+          image: 'Ubuntu-22.04'
           jdk_version: '17'
           jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs


### PR DESCRIPTION
This PR updates the image used in AZPs to `Ubuntu-22.04`