### PR TITLE
Fix the case when we are using KafkaStreams client without tracing

### DIFF
--- a/clients/src/main/java/io/strimzi/common/configuration/Constants.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/Constants.java
@@ -72,6 +72,7 @@ public interface Constants {
      * Common environment variables
      */
     String CLIENT_TYPE_ENV = "CLIENT_TYPE";
+    String TRACING_TYPE_ENV = "TRACING_TYPE";
 
     String HTTP_JSON_CONTENT_TYPE = "application/vnd.kafka.json.v2+json";
 }

--- a/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/common/configuration/kafka/KafkaClientsConfiguration.java
@@ -26,6 +26,7 @@ import static io.strimzi.common.configuration.Constants.OAUTH_REFRESH_TOKEN_ENV;
 import static io.strimzi.common.configuration.Constants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
 import static io.strimzi.common.configuration.Constants.SASL_JAAS_CONFIG_ENV;
 import static io.strimzi.common.configuration.Constants.SASL_MECHANISM_ENV;
+import static io.strimzi.common.configuration.Constants.TRACING_TYPE_ENV;
 import static io.strimzi.common.configuration.Constants.USER_CRT_ENV;
 import static io.strimzi.common.configuration.Constants.USER_KEY_ENV;
 import static io.strimzi.common.configuration.Constants.USER_NAME_ENV;
@@ -48,6 +49,7 @@ public class KafkaClientsConfiguration {
     private final String saslJaasConfig;
     private final String saslUserName;
     private final String saslPassword;
+    private final boolean tracingEnabled;
     private final String saslLoginCallbackClass = "io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler";
 
     public KafkaClientsConfiguration(Map<String, String> map) {
@@ -67,6 +69,7 @@ public class KafkaClientsConfiguration {
         this.saslUserName = map.get(USER_NAME_ENV);
         this.saslPassword = map.get(USER_PASSWORD_ENV);
         this.additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+        this.tracingEnabled = map.get(TRACING_TYPE_ENV) != null;
 
         if (bootstrapServers == null || bootstrapServers.isEmpty()) throw new InvalidParameterException("Bootstrap servers are not set");
     }
@@ -139,6 +142,10 @@ public class KafkaClientsConfiguration {
         return saslLoginCallbackClass;
     }
 
+    public boolean isTracingEnabled() {
+        return tracingEnabled;
+    }
+
     @Override
     public String toString() {
         String sslTruststoreCertificate =
@@ -180,6 +187,7 @@ public class KafkaClientsConfiguration {
             "saslJaasConfig='" + saslJaasConfig + "',\n" +
             "saslUserName='" + this.getSaslUserName() + "',\n" +
             "saslPassword='" + saslPassword + "',\n" +
+            "tracingEnabled='" + this.isTracingEnabled() + "',\n" +
             "additionalConfig='" + this.getAdditionalConfig() + "'";
     }
 }

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTelemetryHandle.java
@@ -20,8 +20,6 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.Topology;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -65,10 +63,10 @@ public class OpenTelemetryHandle implements TracingHandle {
     }
 
     @Override
-    public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
-        KafkaClientSupplier supplier = new TracingKafkaClientSupplier();
-        return new KafkaStreams(topology, props, supplier);
+    public KafkaClientSupplier getStreamsClientSupplier() {
+        return new TracingKafkaClientSupplier();
     }
+
 
     @Override
     public <T> HttpHandle<T> createHttpHandle(String operationName) {

--- a/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/OpenTracingHandle.java
@@ -15,8 +15,7 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.KafkaClientSupplier;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -52,9 +51,9 @@ public class OpenTracingHandle implements TracingHandle {
         TracingUtil.addProperty(props, ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingProducerInterceptor.class.getName());
     }
 
-    // KafkaStreams is not working with OpenTracing from Kafka 3.0.0
     @Override
-    public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
+    // KafkaStreams is not working with OpenTracing from Kafka 3.0.0
+    public KafkaClientSupplier getStreamsClientSupplier() {
         return null;
     }
 

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingHandle.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingHandle.java
@@ -4,8 +4,7 @@
  */
 package io.strimzi.test.tracing;
 
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.KafkaClientSupplier;
 
 import java.util.Properties;
 
@@ -20,7 +19,7 @@ public interface TracingHandle {
     void addTracingPropsToConsumerConfig(Properties props);
     void addTracingPropsToProducerConfig(Properties props);
 
-    KafkaStreams getStreamsWithTracing(Topology topology, Properties props);
+    KafkaClientSupplier getStreamsClientSupplier();
 
     <T> HttpHandle<T> createHttpHandle(String operationName);
 }

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
@@ -87,7 +87,8 @@ public class TracingUtil {
 
         @Override
         public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
-            return null;
+            // because we are not using tracing, we can return KafkaStreams without any changes to properties
+            return new KafkaStreams(topology, props);
         }
 
         @Override

--- a/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
+++ b/tracing/src/main/java/io/strimzi/test/tracing/TracingUtil.java
@@ -4,8 +4,7 @@
  */
 package io.strimzi.test.tracing;
 
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -86,9 +85,8 @@ public class TracingUtil {
         }
 
         @Override
-        public KafkaStreams getStreamsWithTracing(Topology topology, Properties props) {
-            // because we are not using tracing, we can return KafkaStreams without any changes to properties
-            return new KafkaStreams(topology, props);
+        public KafkaClientSupplier getStreamsClientSupplier() {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
This PR should fix the issue with using KafkaStreams client without tracing - in such case, the Job of the client was in Error state, because of the NPE.