### PR TITLE
Remove GC log from the test-clients

### DIFF
--- a/docker-images/scripts/run.sh
+++ b/docker-images/scripts/run.sh
@@ -26,7 +26,4 @@ fi
 # Make sure that we use /dev/urandom
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
 
-# Enable GC logging for memory tracking
-JAVA_OPTS="${JAVA_OPTS} -Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
-
 exec java $JAVA_OPTS -jar $JAR "$@"


### PR DESCRIPTION
This PR removes the GC log from the test-clients, as it wasn't useful in the past and the log was not that readable.