### PR TITLE
Add possibility to specify topic's configuration in admin client

### DIFF
--- a/admin/src/main/java/io/strimzi/arguments/topic/CreateTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/CreateTopicCommand.java
@@ -71,6 +71,11 @@ public class CreateTopicCommand extends BasicTopicCommand {
         return topics;
     }
 
+    /**
+     * Based on {@link #topicConfig} and {@link #topicConfigFilePath} builds configuration of topic that should
+     * be applied during creation.
+     * @return {@link Map} of configuration based on {@link #topicConfig} and {@link #topicConfigFilePath}
+     */
     private Map<String, String> buildTopicConfigurationFromParameter() {
         Map<String, String> topicConfigMap = new HashMap<>();
 
@@ -84,7 +89,7 @@ public class CreateTopicCommand extends BasicTopicCommand {
                 }
             }
         } else if (!topicConfigFilePath.isEmpty()) {
-            topicConfigMap = ConfigurationUtils.getMapOfPropertiesFromConfigurationFile(topicConfigFilePath);
+            return ConfigurationUtils.getMapOfPropertiesFromConfigurationFile(topicConfigFilePath);
         }
 
         return topicConfigMap;

--- a/admin/src/main/java/io/strimzi/arguments/topic/CreateTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/CreateTopicCommand.java
@@ -31,10 +31,10 @@ public class CreateTopicCommand extends BasicTopicCommand {
     @CommandLine.Option(names = {"--topic-rep-factor", "-trf"}, description = "Topic's replication factor", required = true)
     int topicRepFactor;
 
-    @CommandLine.Option(names = {"--topic-config", "-tc"}, description = "Comma-separated list of additional configuration of the topic")
+    @CommandLine.Option(names = {"--topic-config"}, description = "Comma-separated list of additional configuration of the topic")
     String topicConfig = "";
 
-    @CommandLine.Option(names = {"--topic-config-file", "-tcf"}, description = "File path to configuration file for the topic")
+    @CommandLine.Option(names = {"--topic-config-file"}, description = "File path to configuration file for the topic")
     String topicConfigFilePath = "";
 
     @Override

--- a/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
@@ -14,7 +14,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class ConfigurationUtils {
 
@@ -91,6 +93,15 @@ public class ConfigurationUtils {
             System.out.println("Failed to load configuration file - no such file exist");
         }
         return configuration;
+    }
+
+    public static Map<String, String> getMapOfPropertiesFromConfigurationFile(String configFilePath) {
+        return getPropertiesFromConfigurationFile(configFilePath).entrySet().stream().collect(
+            Collectors.toMap(
+                e -> e.getKey().toString(),
+                e -> e.getValue().toString()
+            )
+        );
     }
 
     /**

--- a/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
@@ -95,6 +95,12 @@ public class ConfigurationUtils {
         return configuration;
     }
 
+    /**
+     * Loads Properties from the configuration file specified by {@code configFilePath}
+     * and builds {@link Map} based on it.
+     * @param configFilePath file path to the configuration file
+     * @return {@link Map} with configuration from file
+     */
     public static Map<String, String> getMapOfPropertiesFromConfigurationFile(String configFilePath) {
         return getPropertiesFromConfigurationFile(configFilePath).entrySet().stream().collect(
             Collectors.toMap(


### PR DESCRIPTION
This PR adds possibility to specify topic's additional config during its creation in `admin-client`.
It adds two new options:

`--topic-config` - accepts configuration as comma-separated list
`--topic-config-file` - file path to configuration file, from which is the config `Map<String, String>` created and passed to the `NewTopic` during creation

Fixes #73 