### PR TITLE
Admin-client - use bash script inside the client's container instead of building executable

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -49,8 +49,6 @@ jobs:
       - template: 'templates/setup_docker.yaml'
       - bash: "mvn clean install"
         displayName: "Build Java artifacts"
-      - bash: "make build_admin_cli"
-        displayName: "Build Admin client CLI"
       - bash: "make docker_build --directory=docker-images/"
         displayName: "Build containers"
         env:

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,10 @@ copy_files:
 	mkdir -p docker-images/tmp/
 	cp clients/src/main/resources/log4j2.properties docker-images/tmp/log4j2.properties
 	cp clients/target/clients-$(VERSION).jar docker-images/tmp/clients-$(VERSION).jar
+	cp admin/target/admin-$(VERSION).jar docker-images/tmp/admin-$(VERSION).jar
 
 clean_files:
 	rm -rf docker-images/tmp/*
-
-build_admin_cli: prepare_admin_files docker_build_admin_cli
-
-prepare_admin_files:
-	mkdir -p docker-images/tmp/admin-client
-	cp admin/target/admin-$(VERSION).jar docker-images/tmp/admin-client/admin.jar
 
 next_version:
 	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -47,13 +47,3 @@ docker_push_manifest:
 docker_delete_manifest:
 	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
 	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true
-
-.PHONY: docker_build_admin_cli
-docker_build_admin_cli:
-	docker run \
-	    --user $(shell id -ur):$(shell id -gr) \
-	    -v $(shell pwd)/docker-images/tmp/admin-client:/admin-client \
-	    -w /admin-client \
-	    --entrypoint /bin/sh \
-	    ghcr.io/graalvm/graalvm-community:$(GRAAL_VM_VERSION) \
-	    -c "native-image -jar admin.jar admin-client"

--- a/admin/README.md
+++ b/admin/README.md
@@ -78,17 +78,14 @@ folder with the `config.properties` file will be created.
 
 ## Local development & testing
 
-In case you want to build the CLI tool locally, I recommend to install GraalVM and run
-```bash
-make prepare_admin_files
-cd docker-images/tmp/admin-client
-native-image -jar admin.jar admin-client
+As other clients, the admin client is build using Maven:
+
+```
+mvn clean install -pl admin
 ```
 
-You can use the `make` target:
-```bash
-make build_admin_cli
+and then you can run the client using (replace PROJECT_VERSION with current version of the project, found in root pom.xml):
+
 ```
-that build the application using `ghcr.io/graalvm/graalvm-community` image in Docker container, 
-but you can experience issues with platform dependencies etc., that's why I recommend installing GraalVM on your
-machine and building it completely locally.
+java -jar admin/target/admin-PROJECT_VERSION.jar
+```

--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 ARG JAVA_VERSION=17
 
-RUN microdnf update \
+RUN microdnf update -y \
     && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils -y \
     && microdnf clean all
 

--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -18,14 +18,15 @@ RUN useradd -r -m -u 1001 -g 0 strimzi
 ARG version=latest
 ENV VERSION ${version}
 
-COPY ./scripts/ /bin
+COPY ./scripts/run.sh /bin/run.sh
+COPY ./scripts/admin-client.sh /usr/bin/admin-client
 COPY ./tmp/log4j2.properties /bin/log4j2.properties
 
 COPY tmp/clients-${VERSION}.jar /clients.jar
 COPY tmp/admin-${VERSION}.jar /admin.jar
 
-USER 1001
+RUN chmod +x /usr/bin/admin-client
 
-RUN echo 'alias admin-client="java -jar /admin.jar"' >> ~/.bashrc
+USER 1001
 
 CMD ["/bin/run.sh", "clients.jar"]

--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 ARG JAVA_VERSION=17
 
-RUN microdnf update -y \
+RUN microdnf update \
     && microdnf install java-${JAVA_VERSION}-openjdk-headless shadow-utils -y \
     && microdnf clean all
 

--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -22,10 +22,10 @@ COPY ./scripts/ /bin
 COPY ./tmp/log4j2.properties /bin/log4j2.properties
 
 COPY tmp/clients-${VERSION}.jar /clients.jar
-COPY tmp/admin-client /admin-client
-
-ENV PATH="/admin-client/:$PATH"
+COPY tmp/admin-${VERSION}.jar /admin.jar
 
 USER 1001
+
+RUN echo 'alias admin-client="java -jar /admin.jar"' >> ~/.bashrc
 
 CMD ["/bin/run.sh", "clients.jar"]

--- a/docker-images/scripts/admin-client.sh
+++ b/docker-images/scripts/admin-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -jar /admin.jar "$@"


### PR DESCRIPTION
Currently we are building executable of admin client using GraalVM, which allows to build native applications.
The problem is that this currently works fine for x86, the problem is in case of architectures like ppc64le, s390x and aarch64.
From what I found, GraalVM doesn't contain feature for cross-platform compiling (so from linux/x86 we cannot build executable for linux/aarch64, etc.)

And because we are using this admin-client in the tests that are also executed on aforementioned platforms, we need to unblock it in some way.

This PR removes the build of executable using GraalVM and instead adds bash script into `/usr/bin` of the container image, so the `admin-client` command will still work and no-one needs to specify `java -jar ..` during each command.

I decided to do it this way now, because we are not shipping the admin-client executable anywhere else, just in the image, and in case that it will be needed or we will find a different way, we can always change it.

Fixes #75 