### PR TITLE
Bump dependencies - `jackson` and `oauth`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <junit.platform.runner.version>1.10.0</junit.platform.runner.version>
@@ -30,7 +30,7 @@
         <log4j.version>2.20.0</log4j.version>
         <slf4j-simple.version>2.0.6</slf4j-simple.version>
         <kafka.version>3.7.0</kafka.version>
-        <strimzi-oauth-callback.version>0.14.0</strimzi-oauth-callback.version>
+        <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
         <vertx-core.version>4.2.3</vertx-core.version>
         <netty.version>4.1.72.Final</netty.version>
         <maven-shade.version>3.2.1</maven-shade.version>


### PR DESCRIPTION
This PR bumps dependencies of `jackson` and `oauth` to newer versions