### PR TITLE
add -o --output json, plain option for describe topic

### DIFF
--- a/admin/src/main/java/io/strimzi/Main.java
+++ b/admin/src/main/java/io/strimzi/Main.java
@@ -11,6 +11,7 @@ public class Main {
 
     public static void main(String[] args) {
         CommandLine commandLine = new CommandLine(new KafkaAdminClient());
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
 
         CommandLine.Help.ColorScheme colorScheme = new CommandLine.Help.ColorScheme.Builder()
             .commands(CommandLine.Help.Ansi.Style.bold, CommandLine.Help.Ansi.Style.italic, CommandLine.Help.Ansi.Style.fg_magenta)

--- a/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
@@ -48,8 +48,7 @@ public class DescribeTopicCommand extends BasicTopicCommand {
             });
 
             // provide response
-            final String cmdOutput = DescribeTopicsUtils.getOutput(outputFormat, kafkaTopicDescriptionList);
-            System.out.println(cmdOutput);
+            System.out.println(DescribeTopicsUtils.getOutput(outputFormat, kafkaTopicDescriptionList));
 
         } catch (Exception e) {
             throw new RuntimeException("Unable to describe topics due: " + e);

--- a/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
+++ b/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
@@ -20,6 +20,14 @@ public record KafkaTopicDescription(String name, int partitionCount, int replica
         return replicaCount;
     }
 
+    /**
+     * Extracts the topic name, partition count, and replica count from the {@code adminClientTopicDescription} parameter.
+     * consequently creating {@link KafkaTopicDescription} object.
+     *
+     * @param adminClientTopicDescription The topic description object obtained from Kafka's AdminClient.
+     * @return A new {@link KafkaTopicDescription} object that contains the name of the topic, the number of partitions
+     *         in the topic, and the number of replicas per partition.
+     */
     public static KafkaTopicDescription parseKafkaTopicDescription(final TopicDescription adminClientTopicDescription) {
         final int partitionCount = adminClientTopicDescription.partitions().size();
         // as each partition has the same size, replica count is deduced from first partition

--- a/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
+++ b/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.models;
+
+
+public record KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
+}

--- a/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
+++ b/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
@@ -6,16 +6,7 @@ package io.strimzi.models;
 
 import org.apache.kafka.clients.admin.TopicDescription;
 
-public class KafkaTopicDescription {
-    private String name;
-    private int partitionCount;
-    private int replicaCount;
-
-    private KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
-        this.name = name;
-        this.partitionCount = partitionCount;
-        this.replicaCount = replicaCount;
-    }
+public record KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
 
     public String getName() {
         return name;

--- a/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
+++ b/admin/src/main/java/io/strimzi/models/KafkaTopicDescription.java
@@ -4,6 +4,36 @@
  */
 package io.strimzi.models;
 
+import org.apache.kafka.clients.admin.TopicDescription;
 
-public record KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
+public class KafkaTopicDescription {
+    private String name;
+    private int partitionCount;
+    private int replicaCount;
+
+    private KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
+        this.name = name;
+        this.partitionCount = partitionCount;
+        this.replicaCount = replicaCount;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPartitionCount() {
+        return partitionCount;
+    }
+
+    public int getReplicaCount() {
+        return replicaCount;
+    }
+
+    public static KafkaTopicDescription parseKafkaTopicDescription(final TopicDescription adminClientTopicDescription) {
+        final int partitionCount = adminClientTopicDescription.partitions().size();
+        // as each partition has the same size, replica count is deduced from first partition
+        final int replicaCount = adminClientTopicDescription.partitions().get(0).replicas().size();
+        final String name = adminClientTopicDescription.name();
+        return new KafkaTopicDescription(name, partitionCount, replicaCount);
+    }
 }

--- a/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
@@ -33,6 +33,4 @@ public class DescribeTopicsUtils {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(kafkaTopicDescriptionList);
     }
-
-
 }

--- a/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
@@ -12,6 +12,15 @@ import java.util.List;
 
 public class DescribeTopicsUtils {
 
+    /**
+     * Generates a string representation of a list of KafkaTopicDescription objects by delegating
+     * to either {@link #getPlain(List)} or {@link #getJson(List)}.
+     *
+     * @param outputFormat The output format to be used for generating the string representation.
+     * @param kafkaTopicDescriptionList A list of KafkaTopicDescription objects to be represented as a string.
+     * @return A string representation of the provided list of KafkaTopicDescription objects, formatted according to the specified output format.
+     * @throws JsonProcessingException If an error occurs during JSON serialization when the output format is JSON.
+     */
     public static String getOutput(OutputFormat outputFormat, List<KafkaTopicDescription> kafkaTopicDescriptionList) throws JsonProcessingException {
         return switch (outputFormat) {
             case PLAIN -> getPlain(kafkaTopicDescriptionList);
@@ -19,6 +28,12 @@ public class DescribeTopicsUtils {
         };
     }
 
+    /**
+     * Generates a plain text string representation of a list of KafkaTopicDescription objects.
+     *
+     * @param kafkaTopicDescriptionList A list of KafkaTopicDescription objects to be represented as a string.
+     * @return A plain text string representation of topics.
+     */
     private static String getPlain(List<KafkaTopicDescription> kafkaTopicDescriptionList) {
         StringBuilder s = new StringBuilder();
         for (KafkaTopicDescription topic : kafkaTopicDescriptionList) {
@@ -29,6 +44,13 @@ public class DescribeTopicsUtils {
         return s.toString();
     }
 
+    /**
+     * Generates a JSON string representation of a list of KafkaTopicDescription objects using Jackson's ObjectMapper.
+     *
+     * @param kafkaTopicDescriptionList A list of KafkaTopicDescription objects.
+     * @return A JSON string representation of topics.
+     * @throws JsonProcessingException If an error occurs during serialization to JSON.
+     */
     private static String getJson(List<KafkaTopicDescription> kafkaTopicDescriptionList) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(kafkaTopicDescriptionList);

--- a/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/DescribeTopicsUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.strimzi.models.KafkaTopicDescription;
+
+import java.util.List;
+
+public class DescribeTopicsUtils {
+
+    public static String getOutput(OutputFormat outputFormat, List<KafkaTopicDescription> kafkaTopicDescriptionList) throws JsonProcessingException {
+        return switch (outputFormat) {
+            case PLAIN -> getPlain(kafkaTopicDescriptionList);
+            case JSON -> getJson(kafkaTopicDescriptionList);
+        };
+    }
+
+    private static String getPlain(List<KafkaTopicDescription> kafkaTopicDescriptionList) {
+        StringBuilder s = new StringBuilder();
+        for (KafkaTopicDescription topic : kafkaTopicDescriptionList) {
+            final String singleRecord = String.format("name:%s, partitions:%d, replicas:%d\n",
+                topic.getName(), topic.getPartitionCount(), topic.getReplicaCount());
+            s.append(singleRecord);
+        }
+        return s.toString();
+    }
+
+    private static String getJson(List<KafkaTopicDescription> kafkaTopicDescriptionList) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(kafkaTopicDescriptionList);
+    }
+
+
+}

--- a/admin/src/main/java/io/strimzi/utils/OutputFormat.java
+++ b/admin/src/main/java/io/strimzi/utils/OutputFormat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils;
+
+public enum OutputFormat {
+    JSON("json"),
+    PLAIN("plain");
+
+    private final String format;
+
+    OutputFormat(String format) {
+        this.format = format;
+    }
+
+    @Override
+    public String toString() {
+        return this.format;
+    }
+}

--- a/admin/src/main/java/io/strimzi/utils/OutputFormat.java
+++ b/admin/src/main/java/io/strimzi/utils/OutputFormat.java
@@ -4,6 +4,10 @@
  */
 package io.strimzi.utils;
 
+/**
+ * This enumeration specifies the different types of formats
+ * that can be used to represent and output data.
+ */
 public enum OutputFormat {
     JSON("json"),
     PLAIN("plain");


### PR DESCRIPTION
PR adds implementation for correct handling of `topic describe` command. 
for smoother work with topic description also output format option is added with json and plain possible values. 
Because we are supporting values with options to fool proof the work with them they are set to case insensitive (as error logs provides them in Upper case it is easier to allow that as well). 

