### PR TITLE
Add --if-exists option to topic delete, describe, and alter subcommands and fix --help option functionality

### DIFF
--- a/admin/src/main/java/io/strimzi/arguments/BasicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/BasicCommand.java
@@ -15,9 +15,6 @@ public class BasicCommand implements CommandInterface {
     @CommandLine.Option(names = "--bootstrap-server", description = "Bootstrap server address")
     protected String bootstrapServer;
 
-    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message")
-    boolean usageHelpRequested;
-
     @Override
     public Integer call() {
         throw new UnsupportedOperationException("Not supported");

--- a/admin/src/main/java/io/strimzi/arguments/configure/ConfigureCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/configure/ConfigureCommand.java
@@ -22,4 +22,7 @@ import picocli.CommandLine;
     }
 )
 public class ConfigureCommand {
+
+    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message", scope = CommandLine.ScopeType.INHERIT)
+    boolean usageHelpRequested;
 }

--- a/admin/src/main/java/io/strimzi/arguments/topic/AlterTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/AlterTopicCommand.java
@@ -36,16 +36,18 @@ public class AlterTopicCommand extends IfExistsTopicCommand {
     private Integer alterTopic() {
         try (Admin admin = Admin.create(AdminProperties.adminProperties(this.bootstrapServer))) {
             List<String> topicsInKafka = getListOfTopicsInKafka(admin);
-            checkIfTopicExists(topicsInKafka, this.getListOfTopicNames());
 
             Map<String, NewPartitions> alteredTopics = new HashMap<>();
+            List<String> listOfTopics = checkIfTopicsExistAndReturnUpdatedList(topicsInKafka, this.getListOfTopicNames());
 
-            this.getListOfTopicNames().forEach(topic ->
-                alteredTopics.put(topic, NewPartitions.increaseTo(this.topicPartitions))
-            );
+            if (!listOfTopics.isEmpty()) {
+                listOfTopics.forEach(topic ->
+                    alteredTopics.put(topic, NewPartitions.increaseTo(this.topicPartitions))
+                );
 
-            admin.createPartitions(alteredTopics).all().get();
-            System.out.println("Topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " successfully altered.");
+                admin.createPartitions(alteredTopics).all().get();
+                System.out.println("Topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " successfully altered.");
+            }
             return 0;
         } catch (Exception e) {
             throw new RuntimeException("Unable to alter topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " due: " + e.getCause());

--- a/admin/src/main/java/io/strimzi/arguments/topic/BasicTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/BasicTopicCommand.java
@@ -5,10 +5,15 @@
 package io.strimzi.arguments.topic;
 
 import io.strimzi.arguments.BasicCommand;
+import io.strimzi.constants.Constants;
+import org.apache.kafka.clients.admin.Admin;
 import picocli.CommandLine;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Base for topic command
@@ -49,5 +54,31 @@ public class BasicTopicCommand extends BasicCommand {
         }
 
         return topicNames;
+    }
+
+    /**
+     * From provided list of topics (present in Kafka) it filters the topics with specified prefix.
+     *
+     * @param topicsInKafka     list of topics present in Kafka
+     *
+     * @return  list of topics filtered by prefix
+     */
+    List<String> filterTopicsPresentInKafkaByPrefix(List<String> topicsInKafka) {
+        return topicsInKafka.stream().filter(name -> name.contains(this.getTopicPrefixOrName())).toList();
+    }
+
+    /**
+     * Lists topics that are present in Kafka.
+     *
+     * @param admin     Admin client object configured by user specified configuration
+     *
+     * @return      list of topics present in Kafka
+     *
+     * @throws ExecutionException       execution exception
+     * @throws InterruptedException     interrupted exception
+     * @throws TimeoutException         timeout exception
+     */
+    List<String> getListOfTopicsInKafka(Admin admin) throws ExecutionException, InterruptedException, TimeoutException {
+        return admin.listTopics().names().get(Constants.CALL_TIMEOUT_MS, TimeUnit.MILLISECONDS).stream().toList();
     }
 }

--- a/admin/src/main/java/io/strimzi/arguments/topic/DeleteTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/DeleteTopicCommand.java
@@ -36,10 +36,12 @@ public class DeleteTopicCommand extends IfExistsTopicCommand {
 
             List<String> listOfTopics = all ? filterTopicsPresentInKafkaByPrefix(topicsInKafka) : this.getListOfTopicNames();
 
-            listOfTopics = checkIfTopicExists(topicsInKafka, listOfTopics);
-            admin.deleteTopics(listOfTopics).all().get();
+            listOfTopics = checkIfTopicsExistAndReturnUpdatedList(topicsInKafka, listOfTopics);
 
-            System.out.println("Topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " successfully deleted");
+            if (!listOfTopics.isEmpty()) {
+                admin.deleteTopics(listOfTopics).all().get();
+                System.out.println("Topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " successfully deleted");
+            }
             return 0;
         } catch (Exception e) {
             throw new RuntimeException("Unable to delete topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " due: " + e.getCause());

--- a/admin/src/main/java/io/strimzi/arguments/topic/DeleteTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/DeleteTopicCommand.java
@@ -9,8 +9,6 @@ import org.apache.kafka.clients.admin.Admin;
 import picocli.CommandLine;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 /**
  * Command for topic(s) deletion.
@@ -18,7 +16,7 @@ import java.util.stream.Collectors;
  * Accessed using `admin-client topic delete`
  */
 @CommandLine.Command(name = "delete")
-public class DeleteTopicCommand extends BasicTopicCommand {
+public class DeleteTopicCommand extends IfExistsTopicCommand {
 
     @CommandLine.Option(names = "--all", description = "Flag for deleting all topics with specified prefix, defaults to false")
     boolean all = false;
@@ -34,8 +32,11 @@ public class DeleteTopicCommand extends BasicTopicCommand {
      */
     private Integer deleteTopic() {
         try (Admin admin = Admin.create(AdminProperties.adminProperties(this.bootstrapServer))) {
-            List<String> listOfTopics = all ? getListOfTopicsWithPrefix(admin) : this.getListOfTopicNames();
+            List<String> topicsInKafka = getListOfTopicsInKafka(admin);
 
+            List<String> listOfTopics = all ? filterTopicsPresentInKafkaByPrefix(topicsInKafka) : this.getListOfTopicNames();
+
+            listOfTopics = checkIfTopicExists(topicsInKafka, listOfTopics);
             admin.deleteTopics(listOfTopics).all().get();
 
             System.out.println("Topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " successfully deleted");
@@ -43,9 +44,5 @@ public class DeleteTopicCommand extends BasicTopicCommand {
         } catch (Exception e) {
             throw new RuntimeException("Unable to delete topic(s) with name/prefix: " + this.getTopicPrefixOrName() + " due: " + e.getCause());
         }
-    }
-
-    private List<String> getListOfTopicsWithPrefix(Admin admin) throws ExecutionException, InterruptedException {
-        return admin.listTopics().names().get().stream().filter(name -> name.contains(this.getTopicPrefixOrName())).collect(Collectors.toList());
     }
 }

--- a/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
@@ -20,7 +20,7 @@ import java.util.List;
  * Accessed using `admin-client topic describe`
  */
 @CommandLine.Command(name = "describe")
-public class DescribeTopicCommand extends BasicTopicCommand {
+public class DescribeTopicCommand extends IfExistsTopicCommand {
 
     @CommandLine.Option(names = {"--output", "-o"}, defaultValue = "plain", description = "Output format supports: ${COMPLETION-CANDIDATES}")
     private OutputFormat outputFormat;
@@ -36,6 +36,9 @@ public class DescribeTopicCommand extends BasicTopicCommand {
      */
     private Integer describeTopics() {
         try (Admin admin = Admin.create(AdminProperties.adminProperties(this.bootstrapServer))) {
+            List<String> topicsInKafka = getListOfTopicsInKafka(admin);
+            checkIfTopicExists(topicsInKafka, this.getListOfTopicNames());
+
             List<KafkaTopicDescription> kafkaTopicDescriptionList = new LinkedList<>();
 
             // parse response from java admin

--- a/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/DescribeTopicCommand.java
@@ -37,12 +37,12 @@ public class DescribeTopicCommand extends IfExistsTopicCommand {
     private Integer describeTopics() {
         try (Admin admin = Admin.create(AdminProperties.adminProperties(this.bootstrapServer))) {
             List<String> topicsInKafka = getListOfTopicsInKafka(admin);
-            checkIfTopicExists(topicsInKafka, this.getListOfTopicNames());
+            List<String> desiredTopics = checkIfTopicsExistAndReturnUpdatedList(topicsInKafka, this.getListOfTopicNames());
 
             List<KafkaTopicDescription> kafkaTopicDescriptionList = new LinkedList<>();
 
             // parse response from java admin
-            admin.describeTopics(this.getListOfTopicNames()).topicNameValues().forEach((key, value) -> {
+            admin.describeTopics(desiredTopics).topicNameValues().forEach((key, value) -> {
                 try {
                     kafkaTopicDescriptionList.add(KafkaTopicDescription.parseKafkaTopicDescription(value.get()));
                 } catch (Exception e) {

--- a/admin/src/main/java/io/strimzi/arguments/topic/IfExistsTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/IfExistsTopicCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.arguments.topic;
+
+import picocli.CommandLine;
+
+import java.util.List;
+
+/**
+ * Base command containing extra `--if-exists` option, that is needed only in case of alter, delete, describe commands.
+ * In case that we add this option to {@link BasicTopicCommand}, create command will contain this option as well, which is not
+ * required at the moment.
+ * There is no other way how to exclude this option from the other sub-commands.
+ */
+public class IfExistsTopicCommand extends BasicTopicCommand {
+
+    @CommandLine.Option(names = "--if-exists", description = "Flag for skipping  the topic(s) only in case that exist(s)", scope = CommandLine.ScopeType.LOCAL)
+    boolean ifExists = false;
+
+    /**
+     * Method that checks that all expected Kafka topics are present in Kafka, before particular operation is done.
+     * In case that the {@link #ifExists} is true, the topic (in case that it doesn't exist in Kafka) is removed from the List.
+     * Otherwise, the exception is thrown.
+     *
+     * @param topicsInKafka     topics present in Kafka
+     * @param expectedTopics    list of expected topics that should be in Kafka
+     *
+     * @return  list of topics that should be managed
+     */
+    List<String> checkIfTopicExists(List<String> topicsInKafka, List<String> expectedTopics) {
+        expectedTopics.forEach(expectedTopic -> {
+            if (topicsInKafka.stream().noneMatch(expectedTopic::equals)) {
+                if (!ifExists) {
+                    throw new RuntimeException("No such topic: " + expectedTopic + " exists in Kafka");
+                } else {
+                    System.out.println("Topic: " + expectedTopic + " is not present in Kafka and will be ignored in the following operation.");
+                    // in case that the topic is not present in Kafka, and we don't want to report the error if it doesn't exist (specified by --if-exists)
+                    // we want to remove this topic from the list
+                    expectedTopics.remove(expectedTopic);
+                }
+            }
+        });
+
+        return expectedTopics;
+    }
+}

--- a/admin/src/main/java/io/strimzi/arguments/topic/IfExistsTopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/IfExistsTopicCommand.java
@@ -6,6 +6,7 @@ package io.strimzi.arguments.topic;
 
 import picocli.CommandLine;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -29,7 +30,10 @@ public class IfExistsTopicCommand extends BasicTopicCommand {
      *
      * @return  list of topics that should be managed
      */
-    List<String> checkIfTopicExists(List<String> topicsInKafka, List<String> expectedTopics) {
+    List<String> checkIfTopicsExistAndReturnUpdatedList(List<String> topicsInKafka, List<String> expectedTopics) {
+        // we need to clone it to not catch the ConcurrentModificationException
+        List<String> finalTopics = new ArrayList<>(expectedTopics);
+
         expectedTopics.forEach(expectedTopic -> {
             if (topicsInKafka.stream().noneMatch(expectedTopic::equals)) {
                 if (!ifExists) {
@@ -38,11 +42,11 @@ public class IfExistsTopicCommand extends BasicTopicCommand {
                     System.out.println("Topic: " + expectedTopic + " is not present in Kafka and will be ignored in the following operation.");
                     // in case that the topic is not present in Kafka, and we don't want to report the error if it doesn't exist (specified by --if-exists)
                     // we want to remove this topic from the list
-                    expectedTopics.remove(expectedTopic);
+                    finalTopics.remove(expectedTopic);
                 }
             }
         });
 
-        return expectedTopics;
+        return finalTopics;
     }
 }

--- a/admin/src/main/java/io/strimzi/arguments/topic/TopicCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/topic/TopicCommand.java
@@ -23,4 +23,6 @@ import picocli.CommandLine;
     }
 )
 public class TopicCommand {
+    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message", scope = CommandLine.ScopeType.INHERIT)
+    boolean usageHelpRequested;
 }


### PR DESCRIPTION
This PR adds possibility to specify, if the topics that are not present in Kafka during operations delete, describe, and alter, should or should not be ignored - by specifying the `--if-exists` flag.

Also, this PR fixes the `--help` option not working in most of the sub-commands.

Closes #83 