### PR TITLE
Fix log about non-existing admin-client properties file

### DIFF
--- a/admin/src/main/java/io/strimzi/admin/AdminProperties.java
+++ b/admin/src/main/java/io/strimzi/admin/AdminProperties.java
@@ -24,7 +24,7 @@ public class AdminProperties {
      * @return Kafka Properties
      */
     public static Properties adminProperties(String bootstrapServer) {
-        Properties properties = transformAllLoadedProperties(ConfigurationUtils.getPropertiesFromConfigurationFile());
+        Properties properties = transformAllLoadedProperties(ConfigurationUtils.getAdminClientPropertiesIfExists());
 
         // list of fields that can contain reference to file
         List<String> sslFields = List.of(

--- a/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/ConfigurationUtils.java
@@ -76,13 +76,24 @@ public class ConfigurationUtils {
     }
 
     /**
+     * Checks whether properties for the admin-client exists.
+     * If yes, this properties file is loaded and returned.
+     * Otherwise, empty {@link Properties} object is returned.
+     *
+     * @return  {@link Properties} object with configuration of admin-client
+     */
+    public static Properties getAdminClientPropertiesIfExists() {
+        if (Files.exists(Paths.get(getConfigFilePath()))) {
+            return getPropertiesFromConfigurationFile(getConfigFilePath());
+        }
+
+        return new Properties();
+    }
+
+    /**
      * Loads Properties from the config.properties file
      * @return Properties loaded from the config.properties file
      */
-    public static Properties getPropertiesFromConfigurationFile() {
-        return getPropertiesFromConfigurationFile(getConfigFilePath());
-    }
-
     public static Properties getPropertiesFromConfigurationFile(String configFilePath) {
         File configFile = new File(configFilePath);
         Properties configuration = new Properties();
@@ -121,7 +132,7 @@ public class ConfigurationUtils {
         if (!configurationFileExists()) {
             createConfigurationFolderAndFile();
         }
-        Properties currentConfiguration = getPropertiesFromConfigurationFile();
+        Properties currentConfiguration = getAdminClientPropertiesIfExists();
         currentConfiguration.putAll(properties);
 
         try (FileOutputStream fileOutputStream = new FileOutputStream(getConfigFilePath())) {


### PR DESCRIPTION
This PR fixes following log:

```
Failed to load configuration file - no such file exist
```

which appears every time we execute command and we didn't configure the Admin's properties:

```
> admin-client topic create --bootstrap-server localhost:9092 -t my-topic -tp 1 -trf 1                                                                                                                                                                                     

Failed to load configuration file - no such file exist
Topic(s) with name(prefix): [(name=my-topic, numPartitions=1, replicationFactor=1, replicasAssignments=null, configs={})] and count 1 successfully created
```

This log can confuse others, because it seems like something went wrong, even though the operation was finished successful.