### PR TITLE
Handle commit timeout exception instead of fail whole consumer

### DIFF
--- a/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaConsumerClient.java
@@ -101,14 +101,20 @@ public class KafkaConsumerClient implements ClientsInterface {
 
     public void consumeMessages() {
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+        int recordProcessed = 0;
 
         for (ConsumerRecord<String, String> consumerRecord : records) {
             KafkaConsumerRecord kafkaConsumerRecord = KafkaConsumerRecord.parseKafkaConsumerRecord(consumerRecord);
             String log = kafkaConsumerRecord.logMessage(configuration.getOutputFormat());
             LOGGER.info("Received message: {}", log);
-            consumedMessages++;
+            recordProcessed++;
         }
 
-        consumer.commitSync();
+        try {
+            consumer.commitSync();
+            consumedMessages += recordProcessed;
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to commit the offset: {}", ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
When there is a commit offset timeout, the whole consumer is stopped. In our tests it is not suitable solution as during upgrades it can happen from time to time. This change just notify about commit timeout and will keep the default functionality of Kafka Consumer that will retry it again. This change also keep in place expected behavior of fail fast in case of oauth exceptions.