### PR TITLE
Add quotes for message value in producer

### DIFF
--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -110,7 +110,7 @@ public class KafkaProducerClient implements ClientsInterface {
 
     public ProducerRecord generateMessage(int numOfMessage) {
         return new ProducerRecord(configuration.getTopicName(), null, null, configuration.getMessageKey(),
-            configuration.getMessage() + " - " + numOfMessage, configuration.getHeaders());
+            "\"" + configuration.getMessage() + " - " + numOfMessage + "\"", configuration.getHeaders());
     }
 
     public List<ProducerRecord> generateMessages() {

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -109,6 +109,9 @@ public class KafkaProducerClient implements ClientsInterface {
     }
 
     public ProducerRecord generateMessage(int numOfMessage) {
+        // we are using the double quotes for the Strimzi HTTP Bridge and the HTTP consumers, where the message type is JSON
+        // as part of https://github.com/strimzi/test-clients/issues/96 we should implement a possibility
+        // to specifying the type that user wants to use for sending the messages
         return new ProducerRecord(configuration.getTopicName(), null, null, configuration.getMessageKey(),
             "\"" + configuration.getMessage() + " - " + numOfMessage + "\"", configuration.getHeaders());
     }


### PR DESCRIPTION
This PR brings back the quotes in the message that is send via Kafka producer, to fix the issues we are experiencing with Strimzi HTTP Bridge and the HTTP clients, where we are waiting for JSON-like value, which is actually of type `text`.

As part of it, I created an issue for implementing a way to specify different message types in the clients.