### PR TITLE
Correct echo command in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean_files:
 next_version:
 	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)
 	mvn versions:commit
-	echo -n "$(NEXT_VERSION)" > clients.version
+	echo "$(NEXT_VERSION)\c" > clients.version
 
 release_examples:
 	echo "Changing images in examples to: $(RELEASE_VERSION)"
@@ -34,4 +34,4 @@ release_maven:
 	mvn versions:commit
 
 release_clients_version:
-	echo -n "$(RELEASE_VERSION)" > clients.version
+	echo "$(RELEASE_VERSION)\c" > clients.version


### PR DESCRIPTION
This small PR fixes issue with the `make next_version` and `make release_clients_version` commands, which wrongly passed the "version" env variable to the `clients.version` file. On Mac, when someone executed one of these commands, the `-n DESIRED_VERSION` + newline was added into the file (where the `-n` should work as an option to **not add the newline**).

Instead of the option I'm adding the `\c` which works the same way, but on every system.