### PR TITLE
Continue consumer when it already exists in HTTP Bridge

### DIFF
--- a/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
@@ -119,6 +119,8 @@ public class HttpConsumerClient implements ClientsInterface {
 
             if (response.statusCode() == HttpResponseStatus.OK.code()) {
                 LOGGER.info("Consumer successfully created. Response:\n{}", response.body());
+            } else if (response.statusCode() == HttpResponseStatus.CONFLICT.code()) {
+                LOGGER.info("Consumer already exists. Response:\n{}", response.body());
             } else {
                 throw new RuntimeException(String.format("Failed to create consumer. Status code: %s, response: %s", response.statusCode(), response.body()));
             }


### PR DESCRIPTION
In case the consumer pod gets restarted (due to migration to different node for example), the connection fail, because the consumer with that name already exists in Kafka Bridge. This change allow us to continue with the consumer in such situations.