### PR TITLE
Use data-generator for creating messages payload, add option to specify template and message format type

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Kafka Producer
 * `DELAY_MS` - the delay, in ms, between messages
 * `MESSAGE_COUNT` - the number of messages the producer should send
 * `MESSAGE_KEY` - the message key used by the producer for all messages sent.
+* `MESSAGE` - message which the producer should send
+* `MESSAGE_TEMPLATE` - template from [data-generator](https://github.com/skodjob/data-generator) for messages. It has higher priority than `MESSAGE` evn var.
 * `CA_CRT` - the certificate of the CA which signed the brokers' TLS certificates, for adding to the client's trust store
 * `USER_CRT` - the user's certificate
 * `USER_KEY` - the user's private key
@@ -116,6 +118,8 @@ HTTP Producer
 * `DELAY_MS` - the delay, in ms, between messages
 * `MESSAGE_COUNT` - the number of messages the producer should send
 * `MESSAGE` - message which the producer should send
+* `MESSAGE_TEMPLATE` - template from [data-generator](https://github.com/skodjob/data-generator) for messages. It has higher priority than `MESSAGE` evn var.
+* `MESSAGE_TYPE` - type of message that will be used in records headers. Available are json and text.
 
 HTTP Consumer
 * `HOSTNAME` - hostname of service
@@ -126,6 +130,7 @@ HTTP Consumer
 * `POLL_INTERVAL` - interval, in ms, between polls
 * `POLL_TIMEOUT` - timeout, in ms, of one poll
 * `MESSAGE_COUNT` - the number of messages consumer should receive 
+* `MESSAGE_TYPE` - type of message that will be used in records headers. Available are json and text.
 
 ## Admin Client
 See [README.md](admin/README.md)

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,7 +29,7 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-kubernetes-config-provider</artifactId>
         </dependency>
-        <!-- No logger config yet, should be fixed -->
+        <!-- This is due to limitation of admin client - we don§t want to have kafka related logs in output, could be revisited in the future -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,10 +29,11 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-kubernetes-config-provider</artifactId>
         </dependency>
+        <!-- No logger config yet, should be fixed -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>${sl4j-nop.version}</version>
+            <version>${sl4j.version}</version>
         </dependency>
     </dependencies>
 

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -29,7 +29,7 @@
             <groupId>io.strimzi</groupId>
             <artifactId>kafka-kubernetes-config-provider</artifactId>
         </dependency>
-        <!-- This is due to limitation of admin client - we don§t want to have kafka related logs in output, could be revisited in the future -->
+        <!-- This is due to limitation of admin client - we don't want to have Kafka related logs in output, could be revisited in the future -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>

--- a/clients-common/pom.xml
+++ b/clients-common/pom.xml
@@ -37,5 +37,17 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-api</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.logging.log4j</groupId>-->
+<!--            <artifactId>log4j-slf4j-impl</artifactId>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>data-generator</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/clients-common/pom.xml
+++ b/clients-common/pom.xml
@@ -37,9 +37,5 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.skodjob</groupId>
-            <artifactId>data-generator</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/clients-common/pom.xml
+++ b/clients-common/pom.xml
@@ -37,14 +37,6 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.slf4j</groupId>-->
-<!--            <artifactId>slf4j-api</artifactId>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.apache.logging.log4j</groupId>-->
-<!--            <artifactId>log4j-slf4j-impl</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>data-generator</artifactId>

--- a/clients-common/src/main/java/io/strimzi/configuration/ConfigurationConstants.java
+++ b/clients-common/src/main/java/io/strimzi/configuration/ConfigurationConstants.java
@@ -11,6 +11,7 @@ public interface ConfigurationConstants {
     long DEFAULT_DELAY_MS = 0;
 
     String DEFAULT_MESSAGE = "Hello world";
+    String DEFAULT_MESSAGE_TYPE = "text";
     String DEFAULT_GROUP_ID = "my-group";
     String DEFAULT_CLIENT_ID = "my-consumer";
     String DEFAULT_OUTPUT_FORMAT = "plain";
@@ -54,6 +55,8 @@ public interface ConfigurationConstants {
     String MESSAGE_COUNT_ENV = "MESSAGE_COUNT";
     String DELAY_MS_ENV = "DELAY_MS";
     String MESSAGE_ENV = "MESSAGE";
+    String MESSAGE_TEMPLATE_ENV = "MESSAGE_TEMPLATE";
+    String MESSAGE_TYPE_ENV = "MESSAGE_TYPE";
 
     /**
      * Kafka environment variables
@@ -141,5 +144,5 @@ public interface ConfigurationConstants {
     String CLIENT_TYPE_ENV = "CLIENT_TYPE";
     String TRACING_TYPE_ENV = "TRACING_TYPE";
 
-    String HTTP_JSON_CONTENT_TYPE = "application/vnd.kafka.json.v2+json";
+    String HTTP_CONSUMER_POST_JSON_CONTENT_TYPE = "application/vnd.kafka.v2+json";
 }

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -56,10 +56,20 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>io.skodjob</groupId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -61,10 +61,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.apache.logging.log4j</groupId>-->
-<!--            <artifactId>log4j-slf4j-impl</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>data-generator</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -57,6 +57,18 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.logging.log4j</groupId>-->
+<!--            <artifactId>log4j-slf4j-impl</artifactId>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>io.skodjob</groupId>
+            <artifactId>data-generator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/clients/src/main/java/io/strimzi/common/MessageType.java
+++ b/clients/src/main/java/io/strimzi/common/MessageType.java
@@ -5,9 +5,9 @@
 package io.strimzi.common;
 
 public enum MessageType {
-    text,
-    json,
-    Unknown;
+    TEXT,
+    JSON,
+    UNKNOWN;
 
     public static MessageType getFromString(String value) {
         for (MessageType type : values()) {
@@ -15,6 +15,6 @@ public enum MessageType {
                 return type;
             }
         }
-        return Unknown;
+        return UNKNOWN;
     }
 }

--- a/clients/src/main/java/io/strimzi/common/MessageType.java
+++ b/clients/src/main/java/io/strimzi/common/MessageType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.common;
+
+public enum MessageType {
+    text,
+    json,
+    Unknown;
+
+    public static MessageType getFromString(String value) {
+        for (MessageType type : values()) {
+            if (type.toString().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        return Unknown;
+    }
+}

--- a/clients/src/main/java/io/strimzi/common/MessageType.java
+++ b/clients/src/main/java/io/strimzi/common/MessageType.java
@@ -5,9 +5,15 @@
 package io.strimzi.common;
 
 public enum MessageType {
-    TEXT,
-    JSON,
-    UNKNOWN;
+    TEXT("text"),
+    JSON("json"),
+    UNKNOWN("unknown");
+
+    private final String messageType;
+
+    MessageType(String messageType) {
+        this.messageType = messageType;
+    }
 
     public static MessageType getFromString(String value) {
         for (MessageType type : values()) {
@@ -16,5 +22,10 @@ public enum MessageType {
             }
         }
         return UNKNOWN;
+    }
+
+    @Override
+    public String toString() {
+        return this.messageType;
     }
 }

--- a/clients/src/main/java/io/strimzi/common/MessageType.java
+++ b/clients/src/main/java/io/strimzi/common/MessageType.java
@@ -33,8 +33,6 @@ public enum MessageType {
     }
 
     public static List<MessageType> supportedTypes() {
-        List<MessageType> supportedMessageTypes = Arrays.asList(values());
-        supportedMessageTypes.remove(UNKNOWN);
-        return supportedMessageTypes;
+        return Arrays.stream(values()).filter(item -> item != UNKNOWN).toList();
     }
 }

--- a/clients/src/main/java/io/strimzi/common/MessageType.java
+++ b/clients/src/main/java/io/strimzi/common/MessageType.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.common;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum MessageType {
     TEXT("text"),
     JSON("json"),
@@ -27,5 +30,11 @@ public enum MessageType {
     @Override
     public String toString() {
         return this.messageType;
+    }
+
+    public static List<MessageType> supportedTypes() {
+        List<MessageType> supportedMessageTypes = Arrays.asList(values());
+        supportedMessageTypes.remove(UNKNOWN);
+        return supportedMessageTypes;
     }
 }

--- a/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
@@ -17,6 +17,7 @@ public class HttpClientsConfiguration {
     private final long delay;
     private final int messageCount;
     private final String endpointPrefix;
+    private final String messageType;
 
     public HttpClientsConfiguration(Map<String, String> map) {
         String hostname = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.HOSTNAME_ENV), "");
@@ -25,6 +26,7 @@ public class HttpClientsConfiguration {
         long delay = ClientsConfigurationUtils.parseLongOrDefault(map.get(ConfigurationConstants.DELAY_MS_ENV), ConfigurationConstants.DEFAULT_DELAY_MS);
         int messageCount = ClientsConfigurationUtils.parseIntOrDefault(map.get(ConfigurationConstants.MESSAGE_COUNT_ENV), ConfigurationConstants.DEFAULT_MESSAGES_COUNT);
         String endpointPrefix = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), ConfigurationConstants.DEFAULT_ENDPOINT_PREFIX);
+        this.messageType = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TYPE_ENV), ConfigurationConstants.DEFAULT_MESSAGE_TYPE);
 
         if (hostname == null || hostname.isEmpty()) throw new InvalidParameterException("Hostname is not set.");
 
@@ -64,12 +66,17 @@ public class HttpClientsConfiguration {
         return endpointPrefix;
     }
 
+    public String getMessageType() {
+        return messageType;
+    }
+
     @Override
     public String toString() {
         return "hostname='" + this.getHostname() + "',\n" +
             "port='" + this.getPort() + "',\n" +
             "topic='" + this.getTopic() + "',\n" +
             "delay='" + this.getDelay() + "',\n" +
+            "messageType='" + this.getMessageType() + "',\n" +
             "messageCount='" + this.getMessageCount() + "'";
     }
 }

--- a/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.configuration.http;
 
+import io.strimzi.common.MessageType;
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
 
@@ -27,6 +28,10 @@ public class HttpClientsConfiguration {
         int messageCount = ClientsConfigurationUtils.parseIntOrDefault(map.get(ConfigurationConstants.MESSAGE_COUNT_ENV), ConfigurationConstants.DEFAULT_MESSAGES_COUNT);
         String endpointPrefix = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), ConfigurationConstants.DEFAULT_ENDPOINT_PREFIX);
         this.messageType = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TYPE_ENV), ConfigurationConstants.DEFAULT_MESSAGE_TYPE);
+
+        if (MessageType.getFromString(this.messageType) == MessageType.UNKNOWN) {
+            throw new InvalidParameterException("MESSAGE_TYPE should be 'json' or 'text'");
+        }
 
         if (hostname == null || hostname.isEmpty()) throw new InvalidParameterException("Hostname is not set.");
 

--- a/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/http/HttpClientsConfiguration.java
@@ -30,7 +30,7 @@ public class HttpClientsConfiguration {
         this.messageType = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TYPE_ENV), ConfigurationConstants.DEFAULT_MESSAGE_TYPE);
 
         if (MessageType.getFromString(this.messageType) == MessageType.UNKNOWN) {
-            throw new InvalidParameterException("MESSAGE_TYPE should be 'json' or 'text'");
+            throw new InvalidParameterException("MESSAGE_TYPE should be one of " + MessageType.supportedTypes());
         }
 
         if (hostname == null || hostname.isEmpty()) throw new InvalidParameterException("Hostname is not set.");

--- a/clients/src/main/java/io/strimzi/configuration/http/HttpProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/http/HttpProducerConfiguration.java
@@ -11,16 +11,22 @@ import java.util.Map;
 
 public class HttpProducerConfiguration extends HttpClientsConfiguration {
     private final String message;
+    private final String messageTemplate;
     private final String uri;
 
     public HttpProducerConfiguration(Map<String, String> map) {
         super(map);
         this.message = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_ENV), ConfigurationConstants.DEFAULT_MESSAGE);
+        this.messageTemplate = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TEMPLATE_ENV), null);
         this.uri =  "http://" + this.getHostname() + ":" + this.getPort() + this.getEndpointPrefix() + "/topics/" + this.getTopic();
     }
 
     public String getMessage() {
         return message;
+    }
+
+    public String getMessageTemplate() {
+        return messageTemplate;
     }
 
     public String getUri() {
@@ -32,6 +38,7 @@ public class HttpProducerConfiguration extends HttpClientsConfiguration {
         return "HttpProducerConfiguration:\n" +
             super.toString() + ",\n" +
             "message='" + this.getMessage() + "',\n" +
+            "messageTemplate='" + this.getMessageTemplate() + "',\n" +
             "uri='" + this.getUri() + "'";
     }
 }

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
@@ -22,6 +22,9 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
     private final boolean transactionalProducer;
     private final String message;
     private final String messageKey;
+    private final String messageTemplate;
+    private final String messageType;
+
     public KafkaProducerConfiguration(Map<String, String> map) {
         super(map);
         this.acks = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.PRODUCER_ACKS_ENV), ConfigurationConstants.DEFAULT_PRODUCER_ACKS);
@@ -29,6 +32,8 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.messagesPerTransaction = ClientsConfigurationUtils.parseIntOrDefault(map.get(ConfigurationConstants.MESSAGES_PER_TRANSACTION_ENV), ConfigurationConstants.DEFAULT_MESSAGES_PER_TRANSACTION);
         this.transactionalProducer = getAdditionalConfig().toString().contains(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
         this.message = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_ENV), ConfigurationConstants.DEFAULT_MESSAGE);
+        this.messageTemplate = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TEMPLATE_ENV), null);
+        this.messageType = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TYPE_ENV), ConfigurationConstants.DEFAULT_MESSAGE_TYPE);
         this.messageKey = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_KEY_ENV), null);
         this.topicName = map.get(ConfigurationConstants.TOPIC_ENV);
 
@@ -63,6 +68,14 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         return messageKey;
     }
 
+    public String getMessageTemplate() {
+        return messageTemplate;
+    }
+
+    public String getMessageType() {
+        return messageType;
+    }
+
     @Override
     public String toString() {
         return "KafkaProducerConfiguration:\n" +
@@ -73,6 +86,7 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
             "messagesPerTransaction='" + this.getMessagesPerTransaction() + "',\n" +
             "transactionalProducer='" + this.isTransactionalProducer() + "',\n" +
             "messageKey='" + this.getMessageKey() + "',\n" +
-            "message='" + this.getMessage() + "'";
+            "message='" + this.getMessage() + "',\n" +
+            "messageTemplate='" + this.getMessageTemplate() + "'";
     }
 }

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.configuration.kafka;
 
+import io.strimzi.common.MessageType;
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -38,6 +39,10 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.topicName = map.get(ConfigurationConstants.TOPIC_ENV);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
+
+        if (MessageType.getFromString(this.messageType) == MessageType.UNKNOWN) {
+            throw new InvalidParameterException("MESSAGE_TYPE should be 'json' or 'text'");
+        }
     }
 
     public String getAcks() {

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.configuration.kafka;
 
-import io.strimzi.common.MessageType;
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -24,7 +23,6 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
     private final String message;
     private final String messageKey;
     private final String messageTemplate;
-    private final String messageType;
 
     public KafkaProducerConfiguration(Map<String, String> map) {
         super(map);
@@ -34,15 +32,10 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.transactionalProducer = getAdditionalConfig().toString().contains(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
         this.message = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_ENV), ConfigurationConstants.DEFAULT_MESSAGE);
         this.messageTemplate = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TEMPLATE_ENV), null);
-        this.messageType = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_TYPE_ENV), ConfigurationConstants.DEFAULT_MESSAGE_TYPE);
         this.messageKey = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.MESSAGE_KEY_ENV), null);
         this.topicName = map.get(ConfigurationConstants.TOPIC_ENV);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
-
-        if (MessageType.getFromString(this.messageType) == MessageType.UNKNOWN) {
-            throw new InvalidParameterException("MESSAGE_TYPE should be 'json' or 'text'");
-        }
     }
 
     public String getAcks() {
@@ -75,10 +68,6 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
 
     public String getMessageTemplate() {
         return messageTemplate;
-    }
-
-    public String getMessageType() {
-        return messageType;
     }
 
     @Override

--- a/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
+++ b/clients/src/main/java/io/strimzi/http/consumer/HttpConsumerClient.java
@@ -104,11 +104,12 @@ public class HttpConsumerClient implements ClientsInterface {
     }
 
     public void createConsumer() {
-        String message = "{\"name\":\"" + configuration.getClientId() + "\",\"format\":\"json\",\"auto.offset.reset\":\"earliest\"}";
+        String message = "{\"name\":\"" + configuration.getClientId() + "\",\"format\":\"" +
+            this.configuration.getMessageType() + "\",\"auto.offset.reset\":\"earliest\"}";
 
         LOGGER.info("Creating new consumer:\n{}", message);
 
-        HttpContext context = HttpContext.post(configuration.getConsumerCreationURI(), ConfigurationConstants.HTTP_JSON_CONTENT_TYPE, message);
+        HttpContext context = HttpContext.post(configuration.getConsumerCreationURI(), ConfigurationConstants.HTTP_CONSUMER_POST_JSON_CONTENT_TYPE, message);
 
         HttpHandle<String> httpHandle = TracingUtil.getTracing().createHttpHandle("create-consumer");
         HttpRequest creationRequest = httpHandle.build(context);
@@ -135,7 +136,7 @@ public class HttpConsumerClient implements ClientsInterface {
 
         LOGGER.info("Subscribing consumer: {} to topic: {} with message: {}", configuration.getClientId(), configuration.getTopic(), subscriptionMessage);
 
-        HttpContext context = HttpContext.post(configuration.getSubscriptionURI(), ConfigurationConstants.HTTP_JSON_CONTENT_TYPE, subscriptionMessage);
+        HttpContext context = HttpContext.post(configuration.getSubscriptionURI(), ConfigurationConstants.HTTP_CONSUMER_POST_JSON_CONTENT_TYPE, subscriptionMessage);
 
         HttpHandle<String> httpHandle = TracingUtil.getTracing().createHttpHandle("subscribe-topic");
         HttpRequest subscriptionRequest = httpHandle.build(context);
@@ -156,7 +157,8 @@ public class HttpConsumerClient implements ClientsInterface {
     }
 
     public void consumeMessages() {
-        HttpContext context = HttpContext.get(configuration.getConsumeMessagesURI(), ConfigurationConstants.HTTP_JSON_CONTENT_TYPE);
+        String contentType = "application/vnd.kafka." + this.configuration.getMessageType() + ".v2+json";
+        HttpContext context = HttpContext.get(configuration.getConsumeMessagesURI(), contentType);
         try {
             LOGGER.info("Receiving messages - sending HTTP request to {}", configuration.getConsumeMessagesURI());
 

--- a/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
+++ b/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
@@ -8,7 +8,6 @@ import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
 import io.skodjob.datagenerator.DataGenerator;
 import io.skodjob.datagenerator.enums.ETemplateType;
 import io.strimzi.common.ClientsInterface;
-import io.strimzi.common.MessageType;
 import io.strimzi.configuration.ConfigurationConstants;
 import io.strimzi.configuration.http.HttpProducerConfiguration;
 import io.strimzi.common.records.producer.http.OffsetRecordSent;
@@ -24,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -115,13 +113,13 @@ public class HttpProducerClient implements ClientsInterface {
     public ProducerRecord generateMessage(int numOfMessage) {
         String message;
         if (this.configuration.getMessageTemplate() != null) {
-            message = dataGenerator.generateStringData();
+            message = dataGenerator.generateData();
         } else {
             message = configuration.getMessage() + "-" + numOfMessage;
         }
-        if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
-            message = "\"" + message + "\"";
-        }
+//        if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
+//            message = "\"" + message + "\"";
+//        }
 
         String record = "{\"records\":[{\"key\":\"key-" + numOfMessage + "\",\"value\":" + message + "}]}";
 
@@ -141,12 +139,9 @@ public class HttpProducerClient implements ClientsInterface {
         for (int i = 0; i < configuration.getMessageCount(); i++) {
             String message;
             if (this.configuration.getMessageTemplate() != null) {
-                message = dataGenerator.generateStringData();
+                message = dataGenerator.generateData();
             } else {
                 message = configuration.getMessage() + "-" + i;
-            }
-            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
-                message = "\"" + message + "\"";
             }
 
             record += "{\"key\":\"key-" + i + "\",\"value\":" + message + "}";

--- a/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
+++ b/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
@@ -119,7 +119,7 @@ public class HttpProducerClient implements ClientsInterface {
         } else {
             message = configuration.getMessage() + "-" + numOfMessage;
         }
-        if (Objects.equals(this.configuration.getMessageType(), MessageType.text.name())) {
+        if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
             message = "\"" + message + "\"";
         }
 
@@ -145,7 +145,7 @@ public class HttpProducerClient implements ClientsInterface {
             } else {
                 message = configuration.getMessage() + "-" + i;
             }
-            if (Objects.equals(this.configuration.getMessageType(), MessageType.text.name())) {
+            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
                 message = "\"" + message + "\"";
             }
 

--- a/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
+++ b/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
@@ -117,9 +117,6 @@ public class HttpProducerClient implements ClientsInterface {
         } else {
             message = configuration.getMessage() + "-" + numOfMessage;
         }
-//        if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.TEXT.name())) {
-//            message = "\"" + message + "\"";
-//        }
 
         String record = "{\"records\":[{\"key\":\"key-" + numOfMessage + "\",\"value\":" + message + "}]}";
 
@@ -186,5 +183,3 @@ public class HttpProducerClient implements ClientsInterface {
         }
     }
 }
-
-

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -121,13 +121,13 @@ public class KafkaProducerClient implements ClientsInterface {
         String message;
 
         if (this.configuration.getMessageTemplate() != null) {
-            if (Objects.equals(this.configuration.getMessageType(), MessageType.json.name())) {
+            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.JSON.name())) {
                 message = dataGenerator.generateStringData();
             } else {
                 message = "\"" + dataGenerator.generateStringData() + "\"";
             }
         } else {
-            if (Objects.equals(this.configuration.getMessageType(), MessageType.json.name())) {
+            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.JSON.name())) {
                 message = configuration.getMessage() + " - " + numOfMessage;
             } else {
                 message = "\"" + configuration.getMessage() + " - " + numOfMessage + "\"";

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -7,7 +7,6 @@ package io.strimzi.kafka;
 import io.skodjob.datagenerator.DataGenerator;
 import io.skodjob.datagenerator.enums.ETemplateType;
 import io.strimzi.common.ClientsInterface;
-import io.strimzi.common.MessageType;
 import io.strimzi.common.properties.KafkaProperties;
 import io.strimzi.configuration.ConfigurationConstants;
 import io.strimzi.configuration.kafka.KafkaProducerConfiguration;
@@ -21,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -121,17 +119,9 @@ public class KafkaProducerClient implements ClientsInterface {
         String message;
 
         if (this.configuration.getMessageTemplate() != null) {
-            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.JSON.name())) {
-                message = dataGenerator.generateStringData();
-            } else {
-                message = "\"" + dataGenerator.generateStringData() + "\"";
-            }
+            message = dataGenerator.generateData();
         } else {
-            if (this.configuration.getMessageType().equalsIgnoreCase(MessageType.JSON.name())) {
-                message = configuration.getMessage() + " - " + numOfMessage;
-            } else {
-                message = "\"" + configuration.getMessage() + " - " + numOfMessage + "\"";
-            }
+            message = configuration.getMessage() + " - " + numOfMessage;
         }
 
         return new ProducerRecord(configuration.getTopicName(), null, null, configuration.getMessageKey(),

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -4,8 +4,6 @@
  */
 package io.strimzi.configuration.kafka;
 
-import io.skodjob.datagenerator.DataGenerator;
-import io.skodjob.datagenerator.enums.ETemplateType;
 import io.strimzi.configuration.ConfigurationConstants;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
@@ -88,8 +86,6 @@ public class KafkaProducerConfigurationTest {
                 () -> assertThat(kafkaProducerConfiguration.getMessageTemplate(), is(messageTemplate)),
                 () -> assertThat(kafkaProducerConfiguration.getMessageType(), is(messageType))
         );
-
-        DataGenerator dataGenerator = new DataGenerator(ETemplateType.FLIGHTS);
     }
 
     @Test

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -51,6 +51,8 @@ public class KafkaProducerConfigurationTest {
         String headers = "header_key_one=header_value_one, header_key_two=header_value_two";
         String message = "Muhehe";
         String messageKey = "Key-Muhehe";
+        String messageTemplate = "payment_fiat";
+        String messageType = "text";
         int messagesPerTransaction = 125;
         String additionalConfig = ProducerConfig.TRANSACTIONAL_ID_CONFIG + " = my-id";
 
@@ -65,6 +67,8 @@ public class KafkaProducerConfigurationTest {
         configuration.put(ConfigurationConstants.HEADERS_ENV, headers);
         configuration.put(ConfigurationConstants.MESSAGE_ENV, message);
         configuration.put(ConfigurationConstants.MESSAGE_KEY_ENV, messageKey);
+        configuration.put(ConfigurationConstants.MESSAGE_TEMPLATE_ENV, messageTemplate);
+        configuration.put(ConfigurationConstants.MESSAGE_TYPE_ENV, messageType);
         configuration.put(ConfigurationConstants.MESSAGES_PER_TRANSACTION_ENV, String.valueOf(messagesPerTransaction));
         configuration.put(ConfigurationConstants.ADDITIONAL_CONFIG_ENV, additionalConfig);
 
@@ -78,7 +82,9 @@ public class KafkaProducerConfigurationTest {
                 () -> assertThat(kafkaProducerConfiguration.isTransactionalProducer(), is(true)),
                 () -> assertThat(kafkaProducerConfiguration.getTopicName(), is(topicName)),
                 () -> assertThat(kafkaProducerConfiguration.getBootstrapServers(), is(bootstrapServer)),
-                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageKey))
+                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageKey)),
+                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageTemplate)),
+                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageType))
         );
     }
 

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -4,6 +4,8 @@
  */
 package io.strimzi.configuration.kafka;
 
+import io.skodjob.datagenerator.DataGenerator;
+import io.skodjob.datagenerator.enums.ETemplateType;
 import io.strimzi.configuration.ConfigurationConstants;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
@@ -83,9 +85,11 @@ public class KafkaProducerConfigurationTest {
                 () -> assertThat(kafkaProducerConfiguration.getTopicName(), is(topicName)),
                 () -> assertThat(kafkaProducerConfiguration.getBootstrapServers(), is(bootstrapServer)),
                 () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageKey)),
-                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageTemplate)),
-                () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageType))
+                () -> assertThat(kafkaProducerConfiguration.getMessageTemplate(), is(messageTemplate)),
+                () -> assertThat(kafkaProducerConfiguration.getMessageType(), is(messageType))
         );
+
+        DataGenerator dataGenerator = new DataGenerator(ETemplateType.FLIGHTS);
     }
 
     @Test

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -83,8 +83,7 @@ public class KafkaProducerConfigurationTest {
                 () -> assertThat(kafkaProducerConfiguration.getTopicName(), is(topicName)),
                 () -> assertThat(kafkaProducerConfiguration.getBootstrapServers(), is(bootstrapServer)),
                 () -> assertThat(kafkaProducerConfiguration.getMessageKey(), is(messageKey)),
-                () -> assertThat(kafkaProducerConfiguration.getMessageTemplate(), is(messageTemplate)),
-                () -> assertThat(kafkaProducerConfiguration.getMessageType(), is(messageType))
+                () -> assertThat(kafkaProducerConfiguration.getMessageTemplate(), is(messageTemplate))
         );
     }
 

--- a/clients/src/test/java/io/strimzi/producer/http/HttpProducerClientTest.java
+++ b/clients/src/test/java/io/strimzi/producer/http/HttpProducerClientTest.java
@@ -26,7 +26,7 @@ public class HttpProducerClientTest {
     void testGenerateMessage() {
         int numberOfMessage = 6;
 
-        String desiredJsonMessage = "{\"records\":[{\"key\":\"key-" + numberOfMessage + "\",\"value\":\"" + ConfigurationConstants.DEFAULT_MESSAGE + "-" + numberOfMessage + "\"}]}";
+        String desiredJsonMessage = "{\"records\":[{\"key\":\"key-" + numberOfMessage + "\",\"value\":" + ConfigurationConstants.DEFAULT_MESSAGE + "-" + numberOfMessage + "}]}";
 
         ProducerRecord result = producerClient.generateMessage(numberOfMessage);
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <grpc.version>1.61.0</grpc.version>
         <checkstyle.version>10.8.1</checkstyle.version>
         <picocli.version>4.7.5</picocli.version>
-        <sl4j-nop.version>1.7.36</sl4j-nop.version>
 
         <data.generator.version>0.2.0-SNAPSHOT</data.generator.version>
         <sl4j.version>2.0.13</sl4j.version>
@@ -103,12 +102,6 @@
                 <artifactId>picocli</artifactId>
                 <version>${picocli.version}</version>
             </dependency>
-            <!-- Needed as a dependency of Admin client to not log the SLF4J error -->
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
-                <version>${sl4j-nop.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
@@ -116,7 +109,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
 
         <maven.surefire.version>3.3.1</maven.surefire.version>
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
-        <log4j.version>2.23.1</log4j.version>
         <maven-shade.version>3.2.1</maven-shade.version>
-        <slf4j-simple.version>2.0.6</slf4j-simple.version>
+        <log4j.version>2.23.1</log4j.version>
+        <sl4j.version>2.0.13</sl4j.version>
 
         <kafka.version>3.7.1</kafka.version>
         <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
@@ -44,7 +44,6 @@
         <picocli.version>4.7.5</picocli.version>
 
         <data.generator.version>0.2.0</data.generator.version>
-        <sl4j.version>2.0.13</sl4j.version>
 
         <skipTests>false</skipTests>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <checkstyle.version>10.8.1</checkstyle.version>
         <picocli.version>4.7.5</picocli.version>
 
-        <data.generator.version>0.2.0-SNAPSHOT</data.generator.version>
+        <data.generator.version>0.2.0</data.generator.version>
         <sl4j.version>2.0.13</sl4j.version>
 
         <skipTests>false</skipTests>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,8 @@
 
         <maven.surefire.version>3.3.1</maven.surefire.version>
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
+        <log4j.version>2.23.1</log4j.version>
         <maven-shade.version>3.2.1</maven-shade.version>
-
-        <log4j.version>2.20.0</log4j.version>
         <slf4j-simple.version>2.0.6</slf4j-simple.version>
 
         <kafka.version>3.7.1</kafka.version>
@@ -44,6 +43,9 @@
         <checkstyle.version>10.8.1</checkstyle.version>
         <picocli.version>4.7.5</picocli.version>
         <sl4j-nop.version>1.7.36</sl4j-nop.version>
+
+        <data.generator.version>0.2.0-SNAPSHOT</data.generator.version>
+        <sl4j.version>2.0.13</sl4j.version>
 
         <skipTests>false</skipTests>
     </properties>
@@ -170,6 +172,17 @@
                 <artifactId>kafka-streams</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${sl4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.skodjob</groupId>
+                <artifactId>data-generator</artifactId>
+                <version>${data.generator.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -211,3 +224,4 @@
         </plugins>
     </build>
 </project>
+

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR do the several things:

- Add [data-generator](https://github.com/skodjob/data-generator) dependency to allow generate reasonable messages
- Add option `MESSAGE_TEMPLATE` that refers which template from data-geenrator should be used
- Add option `MESSAGE_TYPE` to indicate how the message should be handled by the clients (text or json atm)

The build will fail until we will release new version of data-generator. I will keep this in draft until we will discuss further steps with the team.

It also resolves https://github.com/strimzi/test-clients/issues/96