### PR TITLE
Fix running tests in build pipeline (and overall)

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -49,6 +49,8 @@ jobs:
       - template: 'templates/setup_docker.yaml'
       - bash: "mvn clean install"
         displayName: "Build Java artifacts"
+      - bash: "mvn test"
+        displayName: "Run unit tests"
       - bash: "make docker_build --directory=docker-images/"
         displayName: "Build containers"
         env:

--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -47,7 +47,7 @@ jobs:
           JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
       - template: 'templates/setup_docker.yaml'
-      - bash: "mvn clean install"
+      - bash: "mvn clean install -DskipTests"
         displayName: "Build Java artifacts"
       - bash: "mvn test"
         displayName: "Run unit tests"

--- a/clients-common/pom.xml
+++ b/clients-common/pom.xml
@@ -9,7 +9,6 @@
         <version>0.9.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.strimzi</groupId>
     <artifactId>clients-common</artifactId>
 
     <properties>
@@ -24,18 +23,8 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -31,18 +31,8 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/clients/src/test/java/io/strimzi/common/records/consumer/http/ConsumerRecordUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/consumer/http/ConsumerRecordUtilsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConsumerRecordUtilsTest {
 

--- a/clients/src/test/java/io/strimzi/common/records/consumer/kafka/KafkaConsumerRecordTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/consumer/kafka/KafkaConsumerRecordTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-class KafkaConsumerRecordTest {
+public class KafkaConsumerRecordTest {
 
     @Test
     void testParseKafkaConsumerRecordsToJson() {

--- a/clients/src/test/java/io/strimzi/common/records/producer/http/OffsetRecordSentUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/producer/http/OffsetRecordSentUtilsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OffsetRecordSentUtilsTest {
 

--- a/clients/src/test/java/io/strimzi/configuration/http/HttpClientsConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/http/HttpClientsConfigurationTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HttpClientsConfigurationTest {
 

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaConsumerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaConsumerConfigurationTest.java
@@ -14,8 +14,8 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaConsumerConfigurationTest {
 

--- a/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -19,10 +19,10 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class KafkaProducerConfigurationTest {
+public class KafkaProducerConfigurationTest {
 
     @Test
     void testDefaultConfiguration() {

--- a/clients/src/test/java/io/strimzi/producer/kafka/KafkaProducerClientTest.java
+++ b/clients/src/test/java/io/strimzi/producer/kafka/KafkaProducerClientTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class KafkaProducerClientTest {
+public class KafkaProducerClientTest {
 
     private Map<String, String> configuration;
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <netty.version>4.1.72.Final</netty.version>
         <maven-shade.version>3.2.1</maven-shade.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
+        <maven.surefire.version>3.2.2</maven.surefire.version>
 
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry.alpha-version>1.34.1-alpha</opentelemetry.alpha-version>
@@ -45,6 +46,9 @@
         <checkstyle.version>10.8.1</checkstyle.version>
         <picocli.version>4.7.5</picocli.version>
         <sl4j-nop.version>1.7.36</sl4j-nop.version>
+
+        <skipTests>false</skipTests>
+        <skip.surefire.tests>false</skip.surefire.tests>
     </properties>
 
     <dependencyManagement>
@@ -60,19 +64,15 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.jupiter.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-runner</artifactId>
-                <version>${junit.platform.runner.version}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -178,6 +178,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,21 +21,19 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <jackson.version>2.16.1</jackson.version>
-        <junit.version>4.13.2</junit.version>
-        <junit.jupiter.version>5.10.0</junit.jupiter.version>
-        <junit.platform.runner.version>1.10.0</junit.platform.runner.version>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
         <hamcrest.version>2.2</hamcrest.version>
 
+        <maven.surefire.version>3.3.1</maven.surefire.version>
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
+        <maven-shade.version>3.2.1</maven-shade.version>
+
         <log4j.version>2.20.0</log4j.version>
         <slf4j-simple.version>2.0.6</slf4j-simple.version>
+
         <kafka.version>3.7.1</kafka.version>
         <strimzi-oauth-callback.version>0.15.0</strimzi-oauth-callback.version>
-        <vertx-core.version>4.2.3</vertx-core.version>
-        <netty.version>4.1.72.Final</netty.version>
-        <maven-shade.version>3.2.1</maven-shade.version>
         <kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
-        <maven.surefire.version>3.2.2</maven.surefire.version>
 
         <opentelemetry.version>1.34.1</opentelemetry.version>
         <opentelemetry.alpha-version>1.34.1-alpha</opentelemetry.alpha-version>
@@ -48,7 +46,6 @@
         <sl4j-nop.version>1.7.36</sl4j-nop.version>
 
         <skipTests>false</skipTests>
-        <skip.surefire.tests>false</skip.surefire.tests>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Until now the unit tests we have in the test-clients repository were not running (at all). There were few issues:

- we had JUnit4 used during the test execution, which caused that no tests were found during `mvn install` or `mvn test`
- the Surefire plugin was missing
- old dependencies/plugins were used (this is connected to the JUnit4 point)
- the step was missing in the build pipeline to actually run the tests (it should have been done during `mvn install`, but it wasn't because of the issues mentioned above)

This PR fixes this issue, together with small clean-up of the dependencies, removal of unused stuff and few bumps of dependencies.