### PR TITLE
Handle timestamp value in response from Bridge

### DIFF
--- a/clients/src/main/java/io/strimzi/common/records/consumer/http/ConsumerRecord.java
+++ b/clients/src/main/java/io/strimzi/common/records/consumer/http/ConsumerRecord.java
@@ -70,7 +70,7 @@ public class ConsumerRecord {
     @Override
     public String toString() {
         return "ConsumerRecord: " +
-            ", topic = " + this.topic +
+            "topic = " + this.topic +
             ", key = " + this.key +
             ", value = " + this.value +
             ", partition = " + this.partition +

--- a/clients/src/main/java/io/strimzi/common/records/consumer/http/ConsumerRecord.java
+++ b/clients/src/main/java/io/strimzi/common/records/consumer/http/ConsumerRecord.java
@@ -12,6 +12,7 @@ public class ConsumerRecord {
     private Object value;
     private int partition;
     private long offset;
+    private Long timestamp;
 
     public void setTopic(String topic) {
         this.topic = topic;
@@ -33,6 +34,10 @@ public class ConsumerRecord {
         this.offset = offset;
     }
 
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
     @Override
     public boolean equals(Object o) {
         // self check
@@ -49,7 +54,8 @@ public class ConsumerRecord {
 
         ConsumerRecord cr = (ConsumerRecord) o;
 
-        return cr.partition == partition &&
+        return Objects.equals(cr.timestamp, timestamp) &&
+            cr.partition == partition &&
             cr.offset == offset &&
             Objects.equals(cr.value, value) &&
             Objects.equals(cr.topic, topic) &&
@@ -68,6 +74,7 @@ public class ConsumerRecord {
             ", key = " + this.key +
             ", value = " + this.value +
             ", partition = " + this.partition +
-            ", offset = " + this.offset;
+            ", offset = " + this.offset +
+            ", timestamp = " + this.timestamp;
     }
 }

--- a/clients/src/test/java/io/strimzi/common/records/consumer/http/ConsumerRecordUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/common/records/consumer/http/ConsumerRecordUtilsTest.java
@@ -14,7 +14,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ConsumerRecordUtilsTest {
 
     @Test
-    void testParseConsumerRecordsFromJson() throws JsonProcessingException {
+    void testParseConsumerRecordsWithTimestampFromJson() throws JsonProcessingException {
+        String response = "[{\"topic\":\"random-topic\",\"key\":\"key-0\",\"value\":\"Hello world-0\",\"partition\":0,\"offset\":0,\"timestamp\":\"1722874490\"}]";
+
+        ConsumerRecord expectedResult = new ConsumerRecord();
+        expectedResult.setPartition(0);
+        expectedResult.setOffset(0);
+        expectedResult.setTopic("random-topic");
+        expectedResult.setKey("key-0");
+        expectedResult.setValue("Hello world-0");
+        expectedResult.setTimestamp(1722874490L);
+
+        ConsumerRecord[] result = ConsumerRecordUtils.parseConsumerRecordsFromJson(response);
+
+        assertThat(result.length, is(1));
+        assertThat(result[0], is(expectedResult));
+    }
+
+    @Test
+    void testParseConsumerRecordsWithoutTimestampFromJson() throws JsonProcessingException {
         String response = "[{\"topic\":\"random-topic\",\"key\":\"key-0\",\"value\":\"Hello world-0\",\"partition\":0,\"offset\":0}]";
 
         ConsumerRecord expectedResult = new ConsumerRecord();


### PR DESCRIPTION
After https://github.com/strimzi/strimzi-kafka-bridge/pull/915 was added into Bridge, we need to handle it in our `ConsumerRecord` for HTTP response -> because without that, we are getting:

```
2024-08-01 16:24:45.758.12287383472543 [1;31mERROR[m HttpConsumerClient:175 - Failed to consume message due to: Unrecognized field "timestamp" (class io.strimzi.common.records.http.consumer.ConsumerRecord), not marked as ignorable (5 known properties: "value", "partition", "offset", "topic", "key"])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 130] (through reference chain: java.lang.Object[][0]->io.strimzi.common.records.http.consumer.ConsumerRecord["timestamp"])
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "timestamp" (class io.strimzi.common.records.http.consumer.ConsumerRecord), not marked as ignorable (5 known properties: "value", "partition", "offset", "topic", "key"])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 130] (through reference chain: java.lang.Object[][0]->io.strimzi.common.records.http.consumer.ConsumerRecord["timestamp"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:1153)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:2224)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1793)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1771)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:316)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:217)
	at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:27)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4899)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3846)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3814)
	at io.strimzi.common.records.http.consumer.ConsumerRecordUtils.parseConsumerRecordsFromJson(ConsumerRecordUtils.java:22)
	at io.strimzi.http.consumer.HttpConsumerClient.consumeMessages(HttpConsumerClient.java:168)
	at io.strimzi.http.consumer.HttpConsumerClient.checkAndReceiveMessages(HttpConsumerClient.java:96)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```
