### PR TITLE
Make Avro serdes configurable

### DIFF
--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -75,6 +75,17 @@
             <groupId>io.skodjob</groupId>
             <artifactId>data-generator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+            <version>${apicurio-registry.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -74,6 +74,20 @@
         <dependency>
             <groupId>io.skodjob</groupId>
             <artifactId>data-generator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-params</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>

--- a/clients/src/main/java/io/strimzi/common/properties/KafkaProperties.java
+++ b/clients/src/main/java/io/strimzi/common/properties/KafkaProperties.java
@@ -10,9 +10,6 @@ import io.strimzi.configuration.kafka.KafkaStreamsConfiguration;
 import io.strimzi.properties.BasicKafkaProperties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Properties;
@@ -21,8 +18,8 @@ public class KafkaProperties {
     public static Properties producerProperties(KafkaProducerConfiguration configuration) {
         Properties properties = BasicKafkaProperties.clientProperties(configuration);
 
-        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, configuration.getKeySerializer());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, configuration.getValueSerializer());
         properties.put(ProducerConfig.ACKS_CONFIG, configuration.getAcks());
 
         return properties;
@@ -33,8 +30,8 @@ public class KafkaProperties {
 
         properties.put(ConsumerConfig.CLIENT_ID_CONFIG, configuration.getClientId());
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, configuration.getGroupId());
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, configuration.getKeyDeserializer());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, configuration.getValueDeserializer());
         properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 
@@ -50,8 +47,8 @@ public class KafkaProperties {
 
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, configuration.getApplicationId());
         properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, configuration.getCommitIntervalMs());
-        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, configuration.getDefaultKeySerde());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, configuration.getDefaultValueSerde());
 
         return properties;
     }

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaConsumerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaConsumerConfiguration.java
@@ -11,6 +11,11 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 
 import java.security.InvalidParameterException;
 import java.util.Map;
+import java.util.Properties;
+
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseMapOfProperties;
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.configuration.ConfigurationConstants.ADDITIONAL_CONFIG_ENV;
 
 
 public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
@@ -31,8 +36,19 @@ public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
         this.outputFormat = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.OUTPUT_FORMAT_ENV), ConfigurationConstants.DEFAULT_OUTPUT_FORMAT);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
-        this.keyDeserializer = map.getOrDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        this.valueDeserializer = map.getOrDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        Properties additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+        if (additionalConfig.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG) != null) {
+            this.keyDeserializer = additionalConfig.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG).toString();
+        } else {
+            this.keyDeserializer = StringDeserializer.class.getName();
+        }
+
+        if (additionalConfig.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG) != null) {
+            this.valueDeserializer = additionalConfig.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG).toString();
+        } else {
+            this.valueDeserializer = StringDeserializer.class.getName();
+        }
     }
 
     public String getGroupId() {

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaConsumerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaConsumerConfiguration.java
@@ -6,6 +6,8 @@ package io.strimzi.configuration.kafka;
 
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 
 import java.security.InvalidParameterException;
 import java.util.Map;
@@ -17,6 +19,8 @@ public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
     private final String clientRack;
     private final String topicName;
     private final String outputFormat;
+    private final String keyDeserializer;
+    private final String valueDeserializer;
 
     public KafkaConsumerConfiguration(Map<String, String> map) {
         super(map);
@@ -27,6 +31,8 @@ public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
         this.outputFormat = ClientsConfigurationUtils.parseStringOrDefault(map.get(ConfigurationConstants.OUTPUT_FORMAT_ENV), ConfigurationConstants.DEFAULT_OUTPUT_FORMAT);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
+        this.keyDeserializer = map.getOrDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        this.valueDeserializer = map.getOrDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
     }
 
     public String getGroupId() {
@@ -47,6 +53,14 @@ public class KafkaConsumerConfiguration extends KafkaClientsConfiguration {
 
     public String getOutputFormat() {
         return outputFormat;
+    }
+
+    public String getKeyDeserializer() {
+        return keyDeserializer;
+    }
+
+    public String getValueDeserializer() {
+        return valueDeserializer;
     }
 
     @Override

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
@@ -6,7 +6,6 @@ package io.strimzi.configuration.kafka;
 
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -14,6 +13,11 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseMapOfProperties;
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.configuration.ConfigurationConstants.ADDITIONAL_CONFIG_ENV;
 
 public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
 
@@ -40,8 +44,19 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.topicName = map.get(ConfigurationConstants.TOPIC_ENV);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
-        this.valueSerializer = map.getOrDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        this.keySerializer = map.getOrDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        Properties additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+        if (additionalConfig.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG) != null) {
+            this.keySerializer = additionalConfig.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).toString();
+        } else {
+            this.keySerializer = StringSerializer.class.getName();
+        }
+
+        if (additionalConfig.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG) != null) {
+            this.valueSerializer = additionalConfig.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG).toString();
+        } else {
+            this.valueSerializer = StringSerializer.class.getName();
+        }
     }
 
     public String getAcks() {

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaProducerConfiguration.java
@@ -6,8 +6,10 @@ package io.strimzi.configuration.kafka;
 
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.security.InvalidParameterException;
 import java.util.List;
@@ -23,6 +25,8 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
     private final String message;
     private final String messageKey;
     private final String messageTemplate;
+    private final String keySerializer;
+    private final String valueSerializer;
 
     public KafkaProducerConfiguration(Map<String, String> map) {
         super(map);
@@ -36,6 +40,8 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
         this.topicName = map.get(ConfigurationConstants.TOPIC_ENV);
 
         if (this.topicName == null || topicName.isEmpty()) throw new InvalidParameterException("Topic is not set");
+        this.valueSerializer = map.getOrDefault(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        this.keySerializer = map.getOrDefault(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
     }
 
     public String getAcks() {
@@ -68,6 +74,14 @@ public class KafkaProducerConfiguration extends KafkaClientsConfiguration {
 
     public String getMessageTemplate() {
         return messageTemplate;
+    }
+
+    public String getKeySerializer() {
+        return keySerializer;
+    }
+
+    public String getValueSerializer() {
+        return valueSerializer;
     }
 
     @Override

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaStreamsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaStreamsConfiguration.java
@@ -6,6 +6,8 @@ package io.strimzi.configuration.kafka;
 
 import io.strimzi.configuration.ClientsConfigurationUtils;
 import io.strimzi.configuration.ConfigurationConstants;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
 
 import java.security.InvalidParameterException;
 import java.util.Map;
@@ -16,6 +18,8 @@ public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
     private final String sourceTopic;
     private final String targetTopic;
     private final long commitIntervalMs;
+    private final String defaultKeySerde;
+    private final String defaultValueSerde;
 
     public KafkaStreamsConfiguration(Map<String, String> map) {
         super(map);
@@ -29,6 +33,8 @@ public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
         if (sourceTopic == null || sourceTopic.isEmpty()) throw new InvalidParameterException("Source topic is not set");
 
         if (targetTopic == null || targetTopic.isEmpty()) throw new InvalidParameterException("Target topic is not set");
+        this.defaultKeySerde = map.getOrDefault(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().toString());
+        this.defaultValueSerde = map.getOrDefault(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().toString());
     }
 
     public String getApplicationId() {
@@ -45,6 +51,14 @@ public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
 
     public long getCommitIntervalMs() {
         return commitIntervalMs;
+    }
+
+    public String getDefaultKeySerde() {
+        return defaultKeySerde;
+    }
+
+    public String getDefaultValueSerde() {
+        return defaultValueSerde;
     }
 
     @Override

--- a/clients/src/main/java/io/strimzi/configuration/kafka/KafkaStreamsConfiguration.java
+++ b/clients/src/main/java/io/strimzi/configuration/kafka/KafkaStreamsConfiguration.java
@@ -11,6 +11,11 @@ import org.apache.kafka.streams.StreamsConfig;
 
 import java.security.InvalidParameterException;
 import java.util.Map;
+import java.util.Properties;
+
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseMapOfProperties;
+import static io.strimzi.configuration.ClientsConfigurationUtils.parseStringOrDefault;
+import static io.strimzi.configuration.ConfigurationConstants.ADDITIONAL_CONFIG_ENV;
 
 
 public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
@@ -33,8 +38,19 @@ public class KafkaStreamsConfiguration extends KafkaClientsConfiguration {
         if (sourceTopic == null || sourceTopic.isEmpty()) throw new InvalidParameterException("Source topic is not set");
 
         if (targetTopic == null || targetTopic.isEmpty()) throw new InvalidParameterException("Target topic is not set");
-        this.defaultKeySerde = map.getOrDefault(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().toString());
-        this.defaultValueSerde = map.getOrDefault(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().toString());
+
+        Properties additionalConfig = parseMapOfProperties(parseStringOrDefault(map.get(ADDITIONAL_CONFIG_ENV), ""));
+        if (additionalConfig.get(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG) != null) {
+            this.defaultKeySerde = additionalConfig.get(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG).toString();
+        } else {
+            this.defaultKeySerde = Serdes.String().getClass().toString();
+        }
+
+        if (additionalConfig.get(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG) != null) {
+            this.defaultValueSerde = additionalConfig.get(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG).toString();
+        } else {
+            this.defaultValueSerde = Serdes.String().getClass().toString();
+        }
     }
 
     public String getApplicationId() {

--- a/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
+++ b/clients/src/main/java/io/strimzi/http/producer/HttpProducerClient.java
@@ -112,7 +112,7 @@ public class HttpProducerClient implements ClientsInterface {
     }
 
     public ProducerRecord generateMessage(int numOfMessage) {
-        String message;
+        Object message;
         if (this.configuration.getMessageTemplate() != null) {
             message = dataGenerator.generateData();
         } else {
@@ -139,7 +139,7 @@ public class HttpProducerClient implements ClientsInterface {
         String record = "{\"records\":[";
 
         for (int i = 0; i < configuration.getMessageCount(); i++) {
-            String message;
+            Object message;
             if (this.configuration.getMessageTemplate() != null) {
                 message = dataGenerator.generateData();
             } else {

--- a/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/kafka/KafkaProducerClient.java
@@ -30,7 +30,7 @@ public class KafkaProducerClient implements ClientsInterface {
 
     private static final Logger LOGGER = LogManager.getLogger(KafkaProducerClient.class);
     private final KafkaProducerConfiguration configuration;
-    private final KafkaProducer producer;
+    private final KafkaProducer<Object, Object> producer;
     private int messageIndex;
     private int messageSuccessfullySent;
     private final ScheduledExecutorService scheduledExecutor;
@@ -116,7 +116,7 @@ public class KafkaProducerClient implements ClientsInterface {
     }
 
     public ProducerRecord generateMessage(int numOfMessage) {
-        String message;
+        Object message;
 
         if (this.configuration.getMessageTemplate() != null) {
             message = dataGenerator.generateData();

--- a/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
+++ b/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
@@ -64,6 +64,8 @@ public class KafkaPropertiesTest {
 
         // check custom properties
         assertThat(producerProperties.getProperty(ProducerConfig.ACKS_CONFIG), is(producerAcks));
+        assertThat(producerProperties.getProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaSerializer"));
     }
 
     @Test

--- a/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
+++ b/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
@@ -57,7 +57,8 @@ public class KafkaPropertiesTest {
 
         String producerAcks = "0";
         configuration.put(PRODUCER_ACKS_ENV, producerAcks);
-        configuration.put(ADDITIONAL_CONFIG_ENV, "value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer");
+        configuration.put(ADDITIONAL_CONFIG_ENV, "value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer\n" +
+            "key.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer");
 
         kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
         producerProperties = KafkaProperties.producerProperties(kafkaProducerConfiguration);
@@ -65,6 +66,8 @@ public class KafkaPropertiesTest {
         // check custom properties
         assertThat(producerProperties.getProperty(ProducerConfig.ACKS_CONFIG), is(producerAcks));
         assertThat(producerProperties.getProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaSerializer"));
+        assertThat(producerProperties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG),
             is("io.apicurio.registry.serde.avro.AvroKafkaSerializer"));
     }
 
@@ -94,6 +97,8 @@ public class KafkaPropertiesTest {
         configuration.put(CLIENT_ID_ENV, clientId);
         configuration.put(GROUP_ID_ENV, groupId);
         configuration.put(CLIENT_RACK_ENV, clientRack);
+        configuration.put(ADDITIONAL_CONFIG_ENV, "value.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer\n" +
+            "key.deserializer=io.apicurio.registry.serde.avro.AvroKafkaDeserializer");
 
         kafkaConsumerConfiguration = new KafkaConsumerConfiguration(configuration);
 
@@ -103,6 +108,10 @@ public class KafkaPropertiesTest {
         assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_ID_CONFIG), is(clientId));
         assertThat(consumerProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG), is(groupId));
         assertThat(consumerProperties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG), is(clientRack));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaDeserializer"));
+        assertThat(consumerProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaDeserializer"));
     }
 
     @Test
@@ -126,6 +135,8 @@ public class KafkaPropertiesTest {
 
         long commitInterval = 7000L;
         configuration.put(COMMIT_INTERVAL_MS_ENV, String.valueOf(commitInterval));
+        configuration.put(ADDITIONAL_CONFIG_ENV, "default.value.serde=io.apicurio.registry.serde.avro.AvroKafkaDeserializer\n" +
+            "default.key.serde=io.apicurio.registry.serde.avro.AvroKafkaDeserializer");
 
         kafkaStreamsConfiguration = new KafkaStreamsConfiguration(configuration);
 
@@ -133,5 +144,9 @@ public class KafkaPropertiesTest {
 
         // check custom properties
         assertThat(streamsProperties.get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG), is(commitInterval));
+        assertThat(streamsProperties.getProperty(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaDeserializer"));
+        assertThat(streamsProperties.getProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG),
+            is("io.apicurio.registry.serde.avro.AvroKafkaDeserializer"));
     }
 }

--- a/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
+++ b/clients/src/test/java/io/strimzi/common/properties/KafkaPropertiesTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.strimzi.configuration.ConfigurationConstants.ADDITIONAL_CONFIG_ENV;
 import static io.strimzi.configuration.ConfigurationConstants.APPLICATION_ID_ENV;
 import static io.strimzi.configuration.ConfigurationConstants.BOOTSTRAP_SERVERS_ENV;
 import static io.strimzi.configuration.ConfigurationConstants.CLIENT_ID_ENV;
@@ -56,6 +57,7 @@ public class KafkaPropertiesTest {
 
         String producerAcks = "0";
         configuration.put(PRODUCER_ACKS_ENV, producerAcks);
+        configuration.put(ADDITIONAL_CONFIG_ENV, "value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer");
 
         kafkaProducerConfiguration = new KafkaProducerConfiguration(configuration);
         producerProperties = KafkaProperties.producerProperties(kafkaProducerConfiguration);

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,9 @@
         <checkstyle.version>10.8.1</checkstyle.version>
         <picocli.version>4.7.5</picocli.version>
 
-        <data.generator.version>0.2.0</data.generator.version>
+        <data.generator.version>0.3.0</data.generator.version>
+
+        <apicurio-registry.version>2.6.1.Final</apicurio-registry.version>
 
         <skipTests>false</skipTests>
     </properties>


### PR DESCRIPTION
We would like to use schema registry with test-clients. This allow us to use apicurio serdes for using clients together with schema registry implementations.