### PR TITLE
Add more ITs with apicurio to verify proper work of avro data

### DIFF
--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -96,7 +96,7 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
             <version>${apicurio-registry.version}</version>
             <exclusions>
                 <exclusion>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -36,6 +36,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
@@ -100,7 +105,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -96,7 +96,7 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
             <version>${apicurio-registry.version}</version>
             <exclusions>
                 <exclusion>

--- a/clients/src/test/java/io/strimzi/integration/AbstractIT.java
+++ b/clients/src/test/java/io/strimzi/integration/AbstractIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.integration;
+
+import io.strimzi.test.container.StrimziKafkaCluster;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AbstractIT {
+    protected static StrimziKafkaCluster kafkaCluster;
+
+    @BeforeAll
+    static void setup() {
+        kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withKraft()
+            .withNumberOfBrokers(1)
+            .withInternalTopicReplicationFactor(1)
+            .withSharedNetwork()
+            .build();
+        kafkaCluster.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        kafkaCluster.stop();
+    }
+
+    protected void createKafkaTopic(String name, Map<String, String> config) throws ExecutionException, InterruptedException {
+        try (Admin admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers()))) {
+
+            NewTopic topic = new NewTopic(name, 1, (short) 1);
+            topic.configs(config);
+
+            admin.createTopics(List.of(topic)).all().get();
+        }
+    }
+}

--- a/clients/src/test/java/io/strimzi/integration/KafkaClientIT.java
+++ b/clients/src/test/java/io/strimzi/integration/KafkaClientIT.java
@@ -7,19 +7,12 @@ package io.strimzi.integration;
 import io.strimzi.configuration.ConfigurationConstants;
 import io.strimzi.kafka.KafkaConsumerClient;
 import io.strimzi.kafka.KafkaProducerClient;
-import io.strimzi.test.container.StrimziKafkaCluster;
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.TopicConfig;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -30,34 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class KafkaClientIT {
-    private static StrimziKafkaCluster kafkaCluster;
-
-    @BeforeEach
-    void setup() {
-        kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
-            .withKraft()
-            .withNumberOfBrokers(1)
-            .withInternalTopicReplicationFactor(1)
-            .withSharedNetwork()
-            .build();
-        kafkaCluster.start();
-    }
-
-    @AfterAll
-    public static void afterAll() {
-        kafkaCluster.stop();
-    }
-
-    private void createKafkaTopic(String name, Map<String, String> config) throws ExecutionException, InterruptedException {
-        try (Admin admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers()))) {
-
-            NewTopic topic = new NewTopic(name, 1, (short) 1);
-            topic.configs(config);
-
-            admin.createTopics(List.of(topic)).all().get();
-        }
-    }
+public class KafkaClientIT extends AbstractIT {
 
     @Test
     void testSimpleExchange() throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {

--- a/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
+++ b/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.integration;
+
+import io.apicurio.registry.rest.v2.beans.IfExists;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.config.IdOption;
+import io.skodjob.datagenerator.enums.ETemplateType;
+import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.kafka.KafkaConsumerClient;
+import io.strimzi.kafka.KafkaProducerClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.TopicConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class KafkaClientWithRegistryIT extends AbstractIT {
+    private static GenericContainer registry;
+
+    @BeforeAll
+    void startRegistry() {
+        registry = new GenericContainer<>(DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem:2.6.5.Final"))
+            .withNetwork(Network.SHARED)
+            .withExposedPorts(8080)
+            .waitingFor(Wait.forHttp("/apis/registry/v2/system/info")
+                .forStatusCode(200));
+        registry.start();
+    }
+
+    @AfterAll
+    void stopRegistry() {
+        registry.stop();
+    }
+
+    private String getRegistryConfig() {
+        return System.lineSeparator() +
+            "apicurio.registry.url=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v2" +
+            System.lineSeparator() +
+            SerdeConfig.ENABLE_CONFLUENT_ID_HANDLER + "=" + Boolean.TRUE +
+            System.lineSeparator() +
+            SerdeConfig.USE_ID + "=" + IdOption.contentId +
+            System.lineSeparator() +
+            SerdeConfig.ENABLE_HEADERS + "=" + Boolean.FALSE +
+            System.lineSeparator() +
+            SerdeConfig.AUTO_REGISTER_ARTIFACT + "=" + Boolean.TRUE +
+            System.lineSeparator() +
+            SerdeConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS + "=" + IfExists.RETURN.name();
+    }
+
+    private Stream<Arguments> getImplementedTemplates() {
+        return Stream.of(
+            Arguments.of(ETemplateType.PAYROLL.name()),
+            Arguments.of(ETemplateType.IOT_DEVICE.name()),
+            Arguments.of(ETemplateType.STARGATE.name()),
+            Arguments.of(ETemplateType.STARWARS.name()),
+            Arguments.of(ETemplateType.PAYMENT_FIAT.name()),
+            Arguments.of(ETemplateType.FLIGHTS.name())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getImplementedTemplates")
+    void testExchangeAvro(String templateName) throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {
+        String topicName = templateName.toLowerCase(Locale.ROOT);
+        Map<String, String> configuration;
+        configuration = new HashMap<>();
+        configuration.put(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, kafkaCluster.getBootstrapServers());
+        configuration.put(ConfigurationConstants.TOPIC_ENV, topicName);
+        configuration.put(ConfigurationConstants.MESSAGE_COUNT_ENV, "100");
+        configuration.put(ConfigurationConstants.MESSAGE_TEMPLATE_ENV, templateName);
+        // Registry config
+        configuration.put("ADDITIONAL_CONFIG", ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG + "=" + AvroKafkaSerializer.class.getName() +
+            getRegistryConfig());
+
+        createKafkaTopic(topicName, Map.of(TopicConfig.RETENTION_MS_CONFIG, "604800000"));
+
+        KafkaProducerClient kafkaProducerClient = new KafkaProducerClient(configuration);
+
+        CompletableFuture<Void> future = CompletableFuture.runAsync(kafkaProducerClient::run);
+        // Wait for the process to complete within a reasonable time
+        future.get(10, TimeUnit.SECONDS);
+
+        Field producedMessages = KafkaProducerClient.class.getDeclaredField("messageSuccessfullySent");
+        producedMessages.setAccessible(true);
+        assertThat(producedMessages.get(kafkaProducerClient), is(100));
+
+        configuration = new HashMap<>();
+        configuration.put(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, kafkaCluster.getBootstrapServers());
+        configuration.put(ConfigurationConstants.TOPIC_ENV, topicName);
+        configuration.put(ConfigurationConstants.MESSAGE_COUNT_ENV, "100");
+        configuration.put(ConfigurationConstants.GROUP_ID_ENV, topicName);
+        configuration.put(ConfigurationConstants.CLIENT_ID_ENV, topicName);
+
+        // Registry config
+        configuration.put("ADDITIONAL_CONFIG", ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG + "=" + AvroKafkaDeserializer.class.getName() +
+            getRegistryConfig());
+
+        KafkaConsumerClient kafkaConsumerClient = new KafkaConsumerClient(configuration);
+
+        future = CompletableFuture.runAsync(kafkaConsumerClient::run);
+        // Wait for the process to complete within a reasonable time
+        future.get(15, TimeUnit.SECONDS);
+
+        Field consumedMessages = KafkaConsumerClient.class.getDeclaredField("consumedMessages");
+        consumedMessages.setAccessible(true);
+        assertThat(consumedMessages.get(kafkaConsumerClient), is(100));
+    }
+}

--- a/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
+++ b/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.integration;
 
-import io.apicurio.registry.rest.v3.beans.IfArtifactExists;
-import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.rest.v2.beans.IfExists;
+import io.apicurio.registry.serde.SerdeConfig;
 import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
 import io.apicurio.registry.serde.config.IdOption;
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class KafkaClientWithRegistryIT extends AbstractIT {
-    private static String registryImage = "quay.io/apicurio/apicurio-registry:3.0.3";
+    private static String registryImage = "quay.io/apicurio/apicurio-registry-mem:2.6.5.Final";
     private static GenericContainer registry;
 
     @BeforeAll
@@ -48,7 +48,7 @@ public class KafkaClientWithRegistryIT extends AbstractIT {
         registry = new GenericContainer<>(DockerImageName.parse(registryImage))
             .withNetwork(Network.SHARED)
             .withExposedPorts(8080)
-            .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
+            .waitingFor(Wait.forHttp("/apis/registry/v2/system/info")
                 .forStatusCode(200));
         registry.start();
     }
@@ -60,13 +60,13 @@ public class KafkaClientWithRegistryIT extends AbstractIT {
 
     private String getRegistryConfig() {
         return System.lineSeparator() +
-            "apicurio.registry.url=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v3" +
+            "apicurio.registry.url=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v2" +
             System.lineSeparator() +
             SerdeConfig.USE_ID + "=" + IdOption.contentId +
             System.lineSeparator() +
             SerdeConfig.AUTO_REGISTER_ARTIFACT + "=" + Boolean.TRUE +
             System.lineSeparator() +
-            SerdeConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS + "=" + IfArtifactExists.FAIL.name();
+            SerdeConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS + "=" + IfExists.RETURN.name();
     }
 
     private Stream<Arguments> getImplementedTemplates() {

--- a/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
+++ b/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
@@ -40,14 +40,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class KafkaClientWithRegistryIT extends AbstractIT {
+    private static String REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry:3.0.3";
     private static GenericContainer registry;
 
     @BeforeAll
     void startRegistry() {
-        registry = new GenericContainer<>(DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem:2.6.5.Final"))
+        registry = new GenericContainer<>(DockerImageName.parse(REGISTRY_IMAGE))
             .withNetwork(Network.SHARED)
             .withExposedPorts(8080)
-            .waitingFor(Wait.forHttp("/apis/registry/v2/system/info")
+            .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
                 .forStatusCode(200));
         registry.start();
     }

--- a/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
+++ b/clients/src/test/java/io/strimzi/integration/KafkaClientWithRegistryIT.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.integration;
 
-import io.apicurio.registry.rest.v2.beans.IfExists;
-import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.rest.v3.beans.IfArtifactExists;
+import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
 import io.apicurio.registry.serde.config.IdOption;
@@ -40,12 +40,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class KafkaClientWithRegistryIT extends AbstractIT {
-    private static String REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry:3.0.3";
+    private static String registryImage = "quay.io/apicurio/apicurio-registry:3.0.3";
     private static GenericContainer registry;
 
     @BeforeAll
     void startRegistry() {
-        registry = new GenericContainer<>(DockerImageName.parse(REGISTRY_IMAGE))
+        registry = new GenericContainer<>(DockerImageName.parse(registryImage))
             .withNetwork(Network.SHARED)
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/apis/registry/v3/system/info")
@@ -60,17 +60,13 @@ public class KafkaClientWithRegistryIT extends AbstractIT {
 
     private String getRegistryConfig() {
         return System.lineSeparator() +
-            "apicurio.registry.url=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v2" +
-            System.lineSeparator() +
-            SerdeConfig.ENABLE_CONFLUENT_ID_HANDLER + "=" + Boolean.TRUE +
+            "apicurio.registry.url=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v3" +
             System.lineSeparator() +
             SerdeConfig.USE_ID + "=" + IdOption.contentId +
             System.lineSeparator() +
-            SerdeConfig.ENABLE_HEADERS + "=" + Boolean.FALSE +
-            System.lineSeparator() +
             SerdeConfig.AUTO_REGISTER_ARTIFACT + "=" + Boolean.TRUE +
             System.lineSeparator() +
-            SerdeConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS + "=" + IfExists.RETURN.name();
+            SerdeConfig.AUTO_REGISTER_ARTIFACT_IF_EXISTS + "=" + IfArtifactExists.FAIL.name();
     }
 
     private Stream<Arguments> getImplementedTemplates() {

--- a/clients/src/test/java/io/strimzi/unit/common/properties/KafkaPropertiesTest.java
+++ b/clients/src/test/java/io/strimzi/unit/common/properties/KafkaPropertiesTest.java
@@ -2,8 +2,9 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.common.properties;
+package io.strimzi.unit.common.properties;
 
+import io.strimzi.common.properties.KafkaProperties;
 import io.strimzi.configuration.kafka.KafkaConsumerConfiguration;
 import io.strimzi.configuration.kafka.KafkaProducerConfiguration;
 import io.strimzi.configuration.kafka.KafkaStreamsConfiguration;

--- a/clients/src/test/java/io/strimzi/unit/common/records/consumer/http/ConsumerRecordUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/unit/common/records/consumer/http/ConsumerRecordUtilsTest.java
@@ -2,9 +2,11 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.common.records.consumer.http;
+package io.strimzi.unit.common.records.consumer.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.strimzi.common.records.consumer.http.ConsumerRecord;
+import io.strimzi.common.records.consumer.http.ConsumerRecordUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/clients/src/test/java/io/strimzi/unit/common/records/consumer/kafka/KafkaConsumerRecordTest.java
+++ b/clients/src/test/java/io/strimzi/unit/common/records/consumer/kafka/KafkaConsumerRecordTest.java
@@ -2,8 +2,9 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.common.records.consumer.kafka;
+package io.strimzi.unit.common.records.consumer.kafka;
 
+import io.strimzi.common.records.consumer.kafka.KafkaConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;

--- a/clients/src/test/java/io/strimzi/unit/common/records/producer/http/OffsetRecordSentUtilsTest.java
+++ b/clients/src/test/java/io/strimzi/unit/common/records/producer/http/OffsetRecordSentUtilsTest.java
@@ -2,9 +2,11 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.common.records.producer.http;
+package io.strimzi.unit.common.records.producer.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.strimzi.common.records.producer.http.OffsetRecordSent;
+import io.strimzi.common.records.producer.http.OffsetRecordSentUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/clients/src/test/java/io/strimzi/unit/configuration/http/HttpClientsConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/http/HttpClientsConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.http;
+package io.strimzi.unit.configuration.http;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.http.HttpClientsConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;

--- a/clients/src/test/java/io/strimzi/unit/configuration/http/HttpConsumerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/http/HttpConsumerConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.http;
+package io.strimzi.unit.configuration.http;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.http.HttpConsumerConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;

--- a/clients/src/test/java/io/strimzi/unit/configuration/http/HttpProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/http/HttpProducerConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.http;
+package io.strimzi.unit.configuration.http;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.http.HttpProducerConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 

--- a/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaConsumerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaConsumerConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.kafka;
+package io.strimzi.unit.configuration.kafka;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.kafka.KafkaConsumerConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;

--- a/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaProducerConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaProducerConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.kafka;
+package io.strimzi.unit.configuration.kafka;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.kafka.KafkaProducerConfiguration;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;

--- a/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaStreamsConfigurationTest.java
+++ b/clients/src/test/java/io/strimzi/unit/configuration/kafka/KafkaStreamsConfigurationTest.java
@@ -2,9 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.configuration.kafka;
+package io.strimzi.unit.configuration.kafka;
 
 import io.strimzi.configuration.ConfigurationConstants;
+import io.strimzi.configuration.kafka.KafkaStreamsConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.security.InvalidParameterException;

--- a/clients/src/test/java/io/strimzi/unit/producer/http/HttpProducerClientTest.java
+++ b/clients/src/test/java/io/strimzi/unit/producer/http/HttpProducerClientTest.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.producer.http;
+package io.strimzi.unit.producer.http;
 
 import io.strimzi.common.records.producer.http.ProducerRecord;
 import io.strimzi.configuration.ConfigurationConstants;

--- a/clients/src/test/java/io/strimzi/unit/producer/kafka/KafkaProducerClientTest.java
+++ b/clients/src/test/java/io/strimzi/unit/producer/kafka/KafkaProducerClientTest.java
@@ -2,7 +2,7 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-package io.strimzi.producer.kafka;
+package io.strimzi.unit.producer.kafka;
 
 import io.strimzi.configuration.ConfigurationConstants;
 import io.strimzi.kafka.KafkaProducerClient;

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <data.generator.version>0.3.0</data.generator.version>
 
-        <apicurio-registry.version>2.6.1.Final</apicurio-registry.version>
+        <apicurio-registry.version>3.0.3</apicurio-registry.version>
 
         <strimzi-test-container.version>0.108.0</strimzi-test-container.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <data.generator.version>0.3.0</data.generator.version>
 
-        <apicurio-registry.version>3.0.3</apicurio-registry.version>
+        <apicurio-registry.version>2.6.5.Final</apicurio-registry.version>
 
         <strimzi-test-container.version>0.108.0</strimzi-test-container.version>
 


### PR DESCRIPTION
This PR adds integration tests with apicurio registry to verify that messaged generated in Avro format works properly on both clients - producer and consumer.