### PR TITLE
Add support for describing nodes using Admin client

### DIFF
--- a/admin/src/main/java/io/strimzi/admin/KafkaAdminClient.java
+++ b/admin/src/main/java/io/strimzi/admin/KafkaAdminClient.java
@@ -5,6 +5,7 @@
 package io.strimzi.admin;
 
 import io.strimzi.arguments.configure.ConfigureCommand;
+import io.strimzi.arguments.nodes.NodeCommand;
 import io.strimzi.arguments.topic.TopicCommand;
 import picocli.CommandLine;
 
@@ -17,7 +18,8 @@ import picocli.CommandLine;
     name = "admin-client",
     subcommands = {
         TopicCommand.class,
-        ConfigureCommand.class
+        ConfigureCommand.class,
+        NodeCommand.class
     }
 )
 public class KafkaAdminClient {

--- a/admin/src/main/java/io/strimzi/arguments/nodes/DescribeNodeCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/nodes/DescribeNodeCommand.java
@@ -1,0 +1,4 @@
+package io.strimzi.arguments.nodes;
+
+public class DescribeNodeCommand {
+}

--- a/admin/src/main/java/io/strimzi/arguments/nodes/DescribeNodeCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/nodes/DescribeNodeCommand.java
@@ -1,4 +1,59 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.arguments.nodes;
 
-public class DescribeNodeCommand {
+import io.strimzi.admin.AdminProperties;
+import io.strimzi.arguments.BasicCommand;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.Node;
+import picocli.CommandLine;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Command for describing the node(s) of the Kafka cluster.
+ * It gets the collection of the nodes using the {@link Admin#describeCluster()} method and then, based on the configuration
+ * of the {@link #nodeIds} - specified by `--node-ids` option - it filters the nodes that we would like to describe.
+ * In case that user specify `all` in the `--node-ids` option, all the nodes will be described.
+ * Otherwise, users can specify IDs - which have to be separated by commas.
+ * This is accessed using `admin-client node describe`
+ */
+@CommandLine.Command(name = "describe")
+public class DescribeNodeCommand extends BasicCommand {
+    @CommandLine.Option(names = {"--node-ids"}, description = "Comma-separated list of nodes which we want to describe. For describing all nodes, you can use `all`.", required = true)
+    String nodeIds;
+
+    @Override
+    public Integer call() {
+        return describeNode();
+    }
+
+    /**
+     * Describes the nodes of the Kafka cluster by connecting to the specified {@link #bootstrapServer}.
+     * Based on the configuration of the {@link #nodeIds}, it filters the nodes and describe them in the console.
+     *
+     * @return return code of the operation
+     */
+    private Integer describeNode() {
+        try (Admin admin = Admin.create(AdminProperties.adminProperties(this.bootstrapServer))) {
+            List<Node> nodes = admin.describeCluster().nodes().get().stream().toList();
+            if (!nodeIds.equals("all")) {
+                List<String> listOfNodeIds = Arrays.stream(nodeIds.split(",")).toList();
+                nodes = nodes.stream().filter(node -> listOfNodeIds.contains(node.idString())).toList();
+            }
+
+            // printing the info for each node
+            nodes.forEach(node -> System.out.println("Node " + node.idString() +
+                "\n  hostname: " + node.host() + ":" + node.port() +
+                "\n  node ID: " + node.idString() +
+                "\n  rack: " + node.rack() + "\n")
+            );
+            return 0;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to list cluster nodes due to: " + e.getCause());
+        }
+    }
 }

--- a/admin/src/main/java/io/strimzi/arguments/nodes/NodeCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/nodes/NodeCommand.java
@@ -1,0 +1,14 @@
+package io.strimzi.arguments.nodes;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "node",
+    subcommands = {
+        DescribeNodeCommand.class
+    }
+)
+public class NodeCommand {
+    @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message", scope = CommandLine.ScopeType.INHERIT)
+    boolean usageHelpRequested;
+}

--- a/admin/src/main/java/io/strimzi/arguments/nodes/NodeCommand.java
+++ b/admin/src/main/java/io/strimzi/arguments/nodes/NodeCommand.java
@@ -1,7 +1,16 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
 package io.strimzi.arguments.nodes;
 
 import picocli.CommandLine;
 
+/**
+ * Class for handling the `node` sub-command.
+ * Its purpose is to handle the nodes of the Kafka cluster - currently just describe the nodes using the `describe` sub-command.
+ * Accessed using `admin-client node`.
+ */
 @CommandLine.Command(
     name = "node",
     subcommands = {

--- a/admin/src/main/java/io/strimzi/constants/Constants.java
+++ b/admin/src/main/java/io/strimzi/constants/Constants.java
@@ -12,4 +12,6 @@ public interface Constants {
     String KEYSTORE_CERT_FILE_NAME = "keystore.crt";
 
     String CONFIG_FOLDER_PATH_ENV = "CONFIG_FOLDER_PATH";
+
+    String ALL_OPTION = "all";
 }

--- a/admin/src/main/java/io/strimzi/utils/DescribeNodesUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/DescribeNodesUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.kafka.common.Node;
+
+import java.util.List;
+
+public class DescribeNodesUtils {
+    /**
+     * Returns the output of the `node describe` command based on the `--output` option.
+     * Possible formats are `plain` (normal text) and `json`.
+     *
+     * @param outputFormat  format we should return the nodes description in
+     * @param nodes         list of nodes
+     *
+     * @return  output of the `node describe` command in specified format
+     * @throws JsonProcessingException  during parsing the JSON
+     */
+    public static String getOutput(OutputFormat outputFormat, List<Node> nodes) throws JsonProcessingException {
+        return switch (outputFormat) {
+            case PLAIN -> getPlainOutput(nodes);
+            case JSON -> getJsonOutput(nodes);
+        };
+    }
+
+    /**
+     * Returns the description of the nodes in plain format.
+     * @param nodes     list of nodes that should have output in plain format
+     * @return the description of the nodes in plain format.
+     */
+    private static String getPlainOutput(List<Node> nodes) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        // build the plain output
+        nodes.forEach(node -> {
+            String nodeDescription = String.format(
+                "Node %s" +
+                "\n  hostname: %s:%s" +
+                "\n  node ID: %s" +
+                "\n  rack: %s\n",
+                node.idString(), node.host(), node.port(), node.idString(), node.rack()
+            );
+
+            stringBuilder.append(nodeDescription);
+        });
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Returns the description of the nodes in JSON format.
+     * @param nodes     list of nodes that should have output in JSON format
+     * @return  the description of the nodes in JSON format.
+     * @throws JsonProcessingException  in case of exception during parsing the JSON object
+     */
+    private static String getJsonOutput(List<Node> nodes) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode root = mapper.createObjectNode();
+        ArrayNode nodesArray = mapper.createArrayNode();
+
+        nodes.forEach(node -> {
+            ObjectNode objectNode = mapper.createObjectNode();
+            objectNode.put("id", node.idString());
+            objectNode.put("hostname", String.format("%s:%s", node.host(), node.id()));
+            objectNode.put("rack", node.rack());
+
+            nodesArray.add(objectNode);
+        });
+
+        root.set("nodes", nodesArray);
+
+        return mapper.writeValueAsString(nodes);
+    }
+}

--- a/examples/admin/admin-client.yaml
+++ b/examples/admin/admin-client.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: admin
-          image: quay.io/strimzi-test-clients/test-clients:latest-kafka-3.9.0
+          image: quay.io/lkral/test-clients@sha256:0cda4245ba738f3ae25d792ae1ad9330316eb754135774044268c8e81fe22c9a
           command: [ "sleep" ]
           args: [ "infinity" ]

--- a/examples/admin/admin-client.yaml
+++ b/examples/admin/admin-client.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: admin
-          image: quay.io/lkral/test-clients@sha256:0cda4245ba738f3ae25d792ae1ad9330316eb754135774044268c8e81fe22c9a
+          image: quay.io/strimzi-test-clients/test-clients:latest-kafka-3.9.0
           command: [ "sleep" ]
           args: [ "infinity" ]


### PR DESCRIPTION
This PR adds support for describing the nodes of the Kafka cluster using our `admin-client`.
The output of the command:

for `plain` output format:
```
> admin-client node describe --bootstrap-server my-cluster-kafka-bootstrap.kafka.svc:9092 --node-ids all --output plain
Node 0
  hostname: my-cluster-broker-0.my-cluster-kafka-brokers.kafka.svc:9092
  node ID: 0
  rack: null

Node 1
  hostname: my-cluster-broker-1.my-cluster-kafka-brokers.kafka.svc:9092
  node ID: 1
  rack: null

Node 2
  hostname: my-cluster-broker-2.my-cluster-kafka-brokers.kafka.svc:9092
  node ID: 2
  rack: null

Node 6
  hostname: my-cluster-broker-6.my-cluster-kafka-brokers.kafka.svc:9092
  node ID: 6
  rack: null

``` 

for `json` output format:
```
> admin-client node describe --bootstrap-server my-cluster-kafka-bootstrap.kafka.svc:9092 --node-ids=all --output=json
{"nodes":[{"id":"0","hostname":"my-cluster-broker-0.my-cluster-kafka-brokers.kafka.svc:0","rack":null},{"id":"1","hostname":"my-cluster-broker-1.my-cluster-kafka-brokers.kafka.svc:1","rack":null},{"id":"2","hostname":"my-cluster-broker-2.my-cluster-kafka-brokers.kafka.svc:2","rack":null},{"id":"6","hostname":"my-cluster-broker-6.my-cluster-kafka-brokers.kafka.svc:6","rack":null}]}
```