### PR TITLE
Allow updating the classpath when starting clients

### DIFF
--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -29,4 +29,4 @@ RUN chmod +x /usr/bin/admin-client
 
 USER 1001
 
-CMD ["/bin/run.sh", "clients.jar"]
+CMD ["/bin/run.sh", "clients.jar", "io.strimzi.Main"]

--- a/docker-images/scripts/admin-client.sh
+++ b/docker-images/scripts/admin-client.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-java -jar /admin.jar "$@"
+export CLASSPATH="/admin.jar:${CLASSPATH}"
+
+java -cp $CLASSPATH io.strimzi.Main

--- a/docker-images/scripts/admin-client.sh
+++ b/docker-images/scripts/admin-client.sh
@@ -2,4 +2,4 @@
 
 export CLASSPATH="/admin.jar:${CLASSPATH}"
 
-java -cp $CLASSPATH io.strimzi.Main
+java -cp $CLASSPATH io.strimzi.Main "$@"

--- a/docker-images/scripts/run.sh
+++ b/docker-images/scripts/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set +x
 
+JAR=$1
+MAIN=$2
+
 # In case we want to use producer, consumer, or streams app in K8s Job, we want to run test-clients jar
 # otherwise we don't want to run anything and let user to use admin-client CLI tool
 if [[ ! -z "${CLIENT_TYPE}" ]]; then
@@ -26,8 +29,10 @@ if [[ ! -z "${CLIENT_TYPE}" ]]; then
       export OAUTH_SSL_TRUSTSTORE_LOCATION=/tmp/oauth-truststore.p12
   fi
 
+  export CLASSPATH="${JAR}:${CLASSPATH}"
+
   # Make sure that we use /dev/urandom
   JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
 
-  exec java $JAVA_OPTS -jar $JAR "$@"
+  exec java $JAVA_OPTS -cp $CLASSPATH $MAIN
 fi


### PR DESCRIPTION
Using `java -jar` prevents updating the classpath and adding custom plugins to the clients. Instead I propose using the `-cp` flag so users can append paths to the classpath.