### PR TITLE
Fix wrong JSON output in node describe command

### DIFF
--- a/admin/src/main/java/io/strimzi/utils/DescribeNodesUtils.java
+++ b/admin/src/main/java/io/strimzi/utils/DescribeNodesUtils.java
@@ -77,6 +77,6 @@ public class DescribeNodesUtils {
 
         root.set("nodes", nodesArray);
 
-        return mapper.writeValueAsString(nodes);
+        return mapper.writeValueAsString(root);
     }
 }


### PR DESCRIPTION
In the previous PR (#114) I accidentally added wrong object for the JSON output. This PR fixes it.