### PR TITLE
Add ITs for admin-client topic commands

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -35,6 +35,44 @@
             <artifactId>slf4j-nop</artifactId>
             <version>${sl4j.version}</version>
         </dependency>
+        <!-- Test related dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>strimzi-test-container</artifactId>
+            <version>${strimzi-test-container.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -57,6 +95,28 @@
                                 </transformer>
                             </transformers>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/IT*.java</include>
+                                <include>**/*IT.java</include>
+                                <include>**/ST*.java</include>
+                                <include>**/*ST.java</include>
+                            </includes>
+                            <trimStackTrace>false</trimStackTrace>
                         </configuration>
                     </execution>
                 </executions>

--- a/admin/src/test/java/admin/integration/AbstractIT.java
+++ b/admin/src/test/java/admin/integration/AbstractIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package admin.integration;
+
+import io.strimzi.admin.KafkaAdminClient;
+import io.strimzi.test.container.StrimziKafkaCluster;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AbstractIT {
+    protected static KafkaAdminClient adminClient = new KafkaAdminClient();
+    protected static CommandLine cmd = new CommandLine(adminClient);
+    protected static StrimziKafkaCluster kafkaCluster;
+    protected static Admin admin;
+
+    protected static final PrintStream ORIGINAL_OUT = System.out;
+    protected static final PrintStream ORIGINAL_ERR = System.err;
+    protected static final ByteArrayOutputStream OUT = new ByteArrayOutputStream();
+    protected static final ByteArrayOutputStream ERR = new ByteArrayOutputStream();
+
+    @BeforeEach
+    public void setUpStreams() {
+        OUT.reset();
+        ERR.reset();
+        System.setOut(new PrintStream(OUT));
+        System.setErr(new PrintStream(ERR));
+    }
+
+    @BeforeAll
+    static void setup() {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+            .withNumberOfBrokers(3)
+            .withInternalTopicReplicationFactor(1)
+            .withSharedNetwork()
+            .build();
+        kafkaCluster.start();
+        cmd.setOut(printWriter);
+        cmd.execute("configure", "common", "--bootstrap-server", kafkaCluster.getBootstrapServers());
+
+        admin = Admin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers()));
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(ORIGINAL_OUT);
+        System.setErr(ORIGINAL_ERR);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        kafkaCluster.stop();
+    }
+}

--- a/admin/src/test/java/admin/integration/AdminTopicIT.java
+++ b/admin/src/test/java/admin/integration/AdminTopicIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package admin.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AdminTopicIT extends AbstractIT {
+
+    @Test
+    void testCreateTopics() throws ExecutionException, InterruptedException {
+        String topicName = "my-topic";
+        String topicPref = "prefixed-topic";
+
+        cmd.execute("topic", "create", "-tp", "2", "-trf", "2", "-t", topicName);
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+
+        Optional<String> topic = admin.listTopics().names().get().stream().filter(t -> t.equals(topicName)).findFirst();
+
+        assertThat(topic.isPresent(), is(true));
+        assertThat(topic.get(), is(topicName));
+
+        TopicDescription topicDescription = admin.describeTopics(List.of(topicName)).allTopicNames().get().get(topicName);
+        assertThat(topicDescription.partitions().size(), is(2));
+        assertThat(topicDescription.partitions().get(0).replicas().size(), is(2));
+
+        cmd.execute("topic", "create", "-tp", "1", "-trf", "1", "-tpref", topicPref, "-fi", "3", "-tc", "10");
+
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+
+        List<String> prefixedTopics = admin.listTopics().names().get().stream()
+            .filter(t -> t.startsWith(topicPref))
+            // Sort the topics by index after the topic prefix -> in order to see that the topic list starts with index 3 so "prefixed-topic-3".
+            .sorted(Comparator.comparingInt(t -> Integer.parseInt(t.split(topicPref + "-")[1])))
+            .toList();
+
+        assertThat(prefixedTopics.size(), is(10));
+        assertThat(prefixedTopics.get(0), is(topicPref + "-3"));
+    }
+
+    @Test
+    void testListTopics() throws InterruptedException {
+        String listTopicPrefix = "list-topic-";
+        List<NewTopic> listTopicsToBeCreated = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            listTopicsToBeCreated.add(new NewTopic(listTopicPrefix + i, 1, (short) 1));
+        }
+
+        admin.createTopics(listTopicsToBeCreated);
+
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+        cmd.execute("topic", "list");
+        List<String> topics = Arrays.stream(OUT.toString().split("\\n")).filter(t -> t.startsWith(listTopicPrefix)).toList();
+
+        assertThat(topics.size(), is(5));
+        assertThat(topics.containsAll(listTopicsToBeCreated.stream().map(NewTopic::name).toList()), is(true));
+    }
+
+    @Test
+    void testDescribeTopic() throws InterruptedException, JsonProcessingException {
+        String topicName = "describe-topic";
+        NewTopic newTopic = new NewTopic(topicName, 3, (short) 2);
+        admin.createTopics(List.of(newTopic));
+
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+
+        cmd.execute("topic", "describe", "-t", topicName);
+        assertThat(OUT.toString().contains("name:describe-topic, partitions:3, replicas:2"), is(true));
+
+        OUT.reset();
+        cmd.execute("topic", "describe", "-t", topicName, "-o", "json");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        JsonNode json = objectMapper.readTree(OUT.toString());
+        JsonNode describedTopic = json.get(0);
+
+        assertThat(describedTopic.get("name").asText(), is(topicName));
+        assertThat(describedTopic.get("partitionCount").asInt(), is(3));
+        assertThat(describedTopic.get("replicaCount").asInt(), is(2));
+    }
+
+    @Test
+    void testDeleteTopic() throws InterruptedException, ExecutionException {
+        String topicName = "delete-topic";
+        NewTopic newTopic = new NewTopic(topicName, 1, (short) 1);
+        admin.createTopics(List.of(newTopic));
+
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+
+        // Check that the topic is really present
+        List<String> topics = admin.listTopics().names().get().stream().toList();
+        assertThat(topics.stream().anyMatch(t -> t.equals(topicName)), is(true));
+
+        // Delete topic using admin-client CLI
+        cmd.execute("topic", "delete", "-t", topicName);
+        assertThat(OUT.toString().contains("Topic(s) with name/prefix: delete-topic successfully deleted"), is(true));
+
+        // Sleep for a while to prevent race condition during topics deletion
+        Thread.sleep(1000);
+        topics = admin.listTopics().names().get().stream().toList();
+        assertThat(topics.stream().anyMatch(t -> t.equals(topicName)), is(false));
+    }
+
+    @Test
+    void testAlterTopic() throws InterruptedException, ExecutionException {
+        String topicName = "alter-topic";
+        NewTopic newTopic = new NewTopic(topicName, 1, (short) 1);
+        admin.createTopics(List.of(newTopic));
+
+        // Sleep for a while to prevent race condition during topics creation
+        Thread.sleep(1000);
+
+        // Alter topic using admin-client
+        cmd.execute("topic", "alter", "-t", topicName, "-tp", "2");
+        assertThat(OUT.toString().contains("Topic(s) with name/prefix: alter-topic successfully altered."), is(true));
+
+        // Sleep for a while to prevent race condition during topics alteration
+        Thread.sleep(1000);
+
+        TopicDescription topicDescription = admin.describeTopics(List.of(topicName)).allTopicNames().get().get(topicName);
+        assertThat(topicDescription.partitions().size(), is(2));
+        assertThat(topicDescription.partitions().get(0).replicas().size(), is(1));
+    }
+}


### PR DESCRIPTION
This PR adds ITs for `admin-client topic` command - for all of the operations available (`create`, `describe`, `list`, `alter`, `delete`), which were missing for quite a long time.