### PR TITLE
Add IT for admin-client node command and one test for fetch-offsets

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -52,25 +52,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>
-            <version>${strimzi-test-container.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/admin/src/test/java/admin/integration/AdminNodeIT.java
+++ b/admin/src/test/java/admin/integration/AdminNodeIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package admin.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AdminNodeIT extends AbstractIT {
+    @Test
+    void testDescribeNodes() throws JsonProcessingException {
+        // firstly describe all nodes
+        cmd.execute("node", "describe", "--node-ids", "all", "-o", "json");
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        JsonNode nodesArray = objectMapper.readTree(OUT.toString());
+        JsonNode nodes = nodesArray.get("nodes");
+
+        assertThat(nodes.size(), is(3));
+
+        OUT.reset();
+        // then describe nodes 0 and 1
+        cmd.execute("node", "describe", "--node-ids", "0,1", "-o", "json");
+        nodesArray = objectMapper.readTree(OUT.toString());
+        nodes = nodesArray.get("nodes");
+
+        assertThat(nodes.size(), is(2));
+
+        List<String> nodeIds = new ArrayList<>();
+
+        for (JsonNode node : nodes) {
+            nodeIds.add(node.get("id").asText());
+        }
+
+        assertThat(nodeIds.containsAll(List.of("0", "1")), is(true));
+
+        OUT.reset();
+
+        // lastly describe just node 2
+        cmd.execute("node", "describe", "--node-ids", "2", "-o", "json");
+
+        nodesArray = objectMapper.readTree(OUT.toString());
+        nodes = nodesArray.get("nodes");
+
+        assertThat(nodes.size(), is(1));
+        assertThat(nodes.get(0).get("id").asText(), is("2"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.jupiter.version}</version>
@@ -184,6 +189,12 @@
                 <groupId>io.skodjob</groupId>
                 <artifactId>data-generator</artifactId>
                 <version>${data.generator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.strimzi</groupId>
+                <artifactId>strimzi-test-container</artifactId>
+                <version>${strimzi-test-container.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR adds IT for `admin-client node describe` command and one more for the topic command -> for the `fetch-offsets` command.
Additionally, it little bit clears up the deps in pom.xmls.