### PR TITLE
Fix SASL scram configuration

### DIFF
--- a/clients-common/src/main/java/io/strimzi/SaslType.java
+++ b/clients-common/src/main/java/io/strimzi/SaslType.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public enum SaslType {
     PLAIN("PLAIN", "PLAIN"),
-    SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA256"),
-    SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA512"),
+    SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA-256"),
+    SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512"),
     UNKNOWN("UNKNOWN", "NONE");
 
     private final String name;

--- a/clients-common/src/main/java/io/strimzi/properties/BasicKafkaProperties.java
+++ b/clients-common/src/main/java/io/strimzi/properties/BasicKafkaProperties.java
@@ -70,7 +70,7 @@ public class BasicKafkaProperties {
         String saslJaasConfig = configuration.getSaslJaasConfig();
 
         if (saslJaasConfig == null) {
-            saslJaasConfig = saslType.equals(SaslType.PLAIN) ? PlainLoginModule.class.toString() : ScramLoginModule.class.toString();
+            saslJaasConfig = saslType.equals(SaslType.PLAIN) ? PlainLoginModule.class.getName() : ScramLoginModule.class.getName();
             saslJaasConfig += String.format(" required username=%s password=%s", configuration.getSaslUserName(), configuration.getSaslPassword());
 
             if (saslType.equals(SaslType.SCRAM_SHA_512)) {


### PR DESCRIPTION
Hi, I hit some issues trying to configure the `admin-client` to use SCRAM-SHA.

When I set `SASL_MECHANISM_ENV` to `SCRAM-SHA-512`, that was converted to `SCRAM-SHA512` in the properties and caused a failure deep in the client SASL code as it doesn't match the mechanism name.

Also, in the generated `sasl.jaas.config` property, there was an unexpected `class ` String before the LoginModule name, like `class org.apache.kafka.common.security.scram.ScramLoginModule required username=admin password=pazz algorithm=SHA-512;`. This also caused the Admin client to fail to instantiate.

To workaround I used `ADDITIONAL_CONFIG` to override `sasl.mechanism`, `sasl.jaas.config` and `security.protocol`