### PR TITLE
Fix push of multiarch images

### DIFF
--- a/.github/actions/build/build-and-push-containers/action.yml
+++ b/.github/actions/build/build-and-push-containers/action.yml
@@ -86,6 +86,7 @@ runs:
         DOCKER_REGISTRY: "quay.io"
         DOCKER_ORG: "strimzi-test-clients"
         DOCKER_TAG: "${{ inputs.dockerTag }}"
+        ARCHITECTURES: ${{ inputs.architecture }}
 
     - name: List built images
       if: ${{ always() }}


### PR DESCRIPTION
This PR fixes issue with pushing images to Quay registry - currently there is only `amd64` image pushed, as the `ARCHITECTURES` env is not set for the push step (the env is used in the `build-images.sh` which takes care of all manipulation of the images). The whole process is wrong and will be changed in one of the following PRs, but this will fix the issue (so we have multi-arch images again).

Fixes #143 