### PR TITLE
Fix warnings from the build of project

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -85,6 +85,15 @@
                                     <mainClass>io.strimzi.testclients.Main</mainClass>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -141,6 +141,15 @@
                                     <mainClass>io.strimzi.testclients.Main</mainClass>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,12 @@
                 <groupId>io.skodjob</groupId>
                 <artifactId>data-generator</artifactId>
                 <version>${data.generator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>


### PR DESCRIPTION
This PR fixes warnings when building the project:

```
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] jackson-databind-2.18.3.jar, jackson-core-2.18.3.jar, picocli-4.7.7.jar, snakeyaml-2.0.jar, slf4j-api-2.0.17.jar, jackson-datatype-jsr310-2.15.2.jar, slf4j-nop-2.0.17.jar, jackson-dataformat-yaml-2.15.2.jar define 1 overlapping classes: 
[WARNING]   - META-INF.versions.9.module-info
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/
```
which is due to having the shaded jar.

```
[WARNING] log4j-slf4j2-impl-2.24.3.jar, log4j-slf4j-impl-2.24.0.jar define 9 overlapping classes: 
[WARNING]   - org.apache.logging.slf4j.message.ThrowableConsumingMessageFactory
[WARNING]   - org.apache.logging.slf4j.message.package-info
[WARNING]   - org.apache.logging.slf4j.Log4jMDCAdapter
[WARNING]   - org.apache.logging.slf4j.package-info
[WARNING]   - org.apache.logging.slf4j.Log4jMarker
[WARNING]   - org.apache.logging.slf4j.Log4jLogger
[WARNING]   - org.apache.logging.slf4j.Log4jLoggerFactory
[WARNING]   - org.apache.logging.slf4j.SLF4JLoggingException
[WARNING]   - org.apache.logging.slf4j.Log4jMarkerFactory
```
which is because `data-generator` is bringing `log4j-slf4j-impl` and we are using `log4j-slf4j2-impl`.