### PR TITLE
Remove `docker_tag` goal from `docker_push_goal`

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -48,7 +48,7 @@ docker_push:
 	$(MAKE) execute_docker_goal goal=docker_push_goal
 
 .PHONY: docker_push_goal
-docker_push_goal: docker_tag
+docker_push_goal:
 	echo "Pushing $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) ..."
 	$(DOCKER_CMD) push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 


### PR DESCRIPTION
This small PR removes the `docker_tag` from `docker_push_goal`, which made loop of tagging and failure in the `docker_push` phase, as the tag in the loop was wrong:

```
make[4]: Entering directory '/home/runner/work/test-clients/test-clients'
echo "Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64 ..."
Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64 ...
docker tag strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64 quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64
Error response from daemon: No such image: strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.0-amd64
make[4]: *** [Makefile.docker:44: docker_tag_goal] Error 1
make[4]: Leaving directory '/home/runner/work/test-clients/test-clients'
make[4]: Entering directory '/home/runner/work/test-clients/test-clients'
echo "Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64 ..."
Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64 ...
docker tag strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64 quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64
Error response from daemon: No such image: strimzi/test-clients:latest-kafka-4.1.1-kafka-4.1.1-amd64
make[4]: *** [Makefile.docker:44: docker_tag_goal] Error 1
make[4]: Leaving directory '/home/runner/work/test-clients/test-clients'
make[4]: Entering directory '/home/runner/work/test-clients/test-clients'
echo "Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64 ..."
Tagging strimzi/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64 to quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64 ...
docker tag strimzi/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64 quay.io/strimzi-test-clients/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64
Error response from daemon: No such image: strimzi/test-clients:latest-kafka-4.1.1-kafka-4.2.0-amd64
```
the images are already tagged as part of the GHA (as there is `docker_tag docker_push`), so the additional tag here is not needed.