### PR TITLE
Fix GHA status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/strimzi/test-clients/actions/workflows/build.yml/badge.svg?branch=main)
+[![Build](https://github.com/strimzi/test-clients/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/strimzi/test-clients/actions/workflows/build.yml?query=branch:main)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio?style=social)](https://twitter.com/strimziio)
 


### PR DESCRIPTION
Small PR fixing the GHA status badge - pointing directly to the build on main branch and adding link to the builds for the main branch.