### PR TITLE
Publish clients-common as it is required by builders module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,4 +102,4 @@ jobs:
           centralUsername: ${{ secrets.CENTRAL_USERNAME }}
           centralPassword: ${{ secrets.CENTRAL_PASSWORD }}
           artifactSuffix: "test-clients"
-          modules: "builders"
+          modules: "clients-common,builders"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           centralUsername: ${{ secrets.CENTRAL_USERNAME }}
           centralPassword: ${{ secrets.CENTRAL_PASSWORD }}
           artifactSuffix: "test-clients"
-          modules: "builders"
+          modules: "clients-common,builders"
 
   push-containers:
     name: Push Containers (${{ inputs.releaseVersion }})


### PR DESCRIPTION
In the `builders` module we are using some things from the `clients-common` module - and until now we didn't release it to Maven central. The job wasn't failing before due to some Maven cache, but once I added another thing to the `clients-common` that was used in `builders`, the deploy Java GHA started failing - plus when you try to import the dependency it fails on this missing dep.