### PR TITLE
Add support for sending Jsonschema and Avro messages.

### DIFF
--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,0 +1,101 @@
+# Schema Serialization in test-clients
+
+This document explains how Kafka messages are serialized using Apicurio Registry schemas in the
+`testclients` library, why each schema type requires a different approach, and what configuration
+is needed for each. This behaviour was confirmed with the Apicurio maintainer, so it should be accurate.
+
+---
+
+## Context
+
+The `testclients` accept messages as plain JSON strings and convert them internally into
+typed objects before handing them to the Apicurio Kafka SerDes. This is necessary because the
+SerDes use the message object to extract schema information — for Avro and Protobuf,
+the schema is embedded in the typed object (`GenericRecord`, `DynamicMessage`). For JSON Schema,
+no such typed wrapper exists and we are forced to use `JsonNode`.
+
+---
+
+## How Schema Resolution Works
+
+The Apicurio `SchemaResolver` resolves a schema in two ways:
+
+1. **From the data object** — calls `SchemaParser.getSchemaFromData()`. This works for Avro and
+   Protobuf because `GenericRecord` and `DynamicMessage` have the schema wrapped inside them..
+
+2. **From explicit coordinates** — this calls `DefaultSchemaResolver.resolveSchemaByCoordinates()` using
+   `EXPLICIT_ARTIFACT_ID` + `EXPLICIT_ARTIFACT_GROUP_ID`. Required for JSON Schema because
+   `JsonSchemaParser.supportsExtractSchemaFromData()` returns `false` — the schema can never
+   be taken from a plain `JsonNode`.
+
+---
+
+## Schema Types
+
+### Avro
+**Example `ADDITIONAL_CONFIG`:**
+
+```properties
+value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
+apicurio.registry.url=http://<registry-host>/apis/registry/v2
+apicurio.registry.group-id=default
+apicurio.registry.artifact-id=<topic-name>-value
+apicurio.registry.artifact-version=1
+apicurio.registry.api-version=v2
+apicurio.registry.find-latest=true
+apicurio.registry.auto-register=false
+```
+
+### Protobuf
+
+**Example `ADDITIONAL_CONFIG`:**
+
+```properties
+value.serializer=io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer
+apicurio.registry.api-url=http://<registry-host>/apis/registry/v3
+apicurio.registry.group-id=default
+apicurio.registry.artifact-id=<topic-name>-value
+apicurio.registry.artifact-version=1
+apicurio.registry.api-version=v3
+apicurio.registry.headers.enabled=true
+apicurio.registry.find-latest=true
+apicurio.registry.auto-register=false
+```
+---
+
+### JSON Schema
+
+JSON Schema is **validation-only** — there is no schema-aware wrapper equivalent to
+`GenericRecord` or `DynamicMessage`. The message is parsed into a plain `JsonNode`, which
+serializes to JSON bytes. The SerDes validate it against the schema and then writes the bytes.
+
+Because `JsonSchemaParser.supportsExtractSchemaFromData()` returns `false`, the schema
+can't be taken from the plain data. The resolver calls the schema lookup
+using `EXPLICIT_ARTIFACT_ID` + `EXPLICIT_ARTIFACT_GROUP_ID`.
+
+**Examples `ADDITIONAL_CONFIG`:**
+
+```properties
+value.serializer=io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer
+apicurio.registry.url=http://<registry-host>/apis/registry/v2
+apicurio.registry.explicit-artifact-id=<topic-name>-value
+apicurio.registry.explicit-artifact-group-id=default
+apicurio.registry.find-latest=true
+apicurio.registry.auto-register=false
+```
+
+> Unlike Avro and Protobuf, JSON Schema does'nt need manual schema fetching —
+> there is no object to build. The SerDes resolve the schema from the registry
+> directly via the explicit coordinates. No `apicurio.registry.artifact-id` but
+> (uses `SerdeConfig.EXPLICIT_ARTIFACT_ID` instead).
+
+---
+
+## References
+
+- [Schema resolver](https://www.apicur.io/registry/docs/apicurio-registry/3.1.x/getting-started/assembly-configuring-kafka-client-serdes.html#_schemaresolver_interface)
+- [Serde config](https://www.apicur.io/registry/docs/apicurio-registry/3.1.x/getting-started/assembly-configuring-kafka-client-serdes.html)
+- 
+- `ProtobufMessageUtils` — Protobuf schema fetch + `DynamicMessage` build
+- `AvroMessageUtils` — Avro schema fetch + `GenericRecord` build
+- `JsonMessageUtils` — plain `JsonNode` parsing

--- a/clients-common/src/main/java/io/strimzi/testclients/configuration/ConfigurationConstants.java
+++ b/clients-common/src/main/java/io/strimzi/testclients/configuration/ConfigurationConstants.java
@@ -154,7 +154,6 @@ public interface ConfigurationConstants {
     String APICURIO_API_V2 = "v2";
 
     // Apicurio registry configuration keys
-    String REGISTRY_URL = "apicurio.registry.url";
     String REGISTRY_GROUP_ID = "apicurio.registry.group-id";
     String REGISTRY_ARTIFACT_ID = "apicurio.registry.artifact-id";
     String REGISTRY_ARTIFACT_VERSION = "apicurio.registry.artifact-version";

--- a/clients/src/main/java/io/strimzi/testclients/kafka/KafkaProducerClient.java
+++ b/clients/src/main/java/io/strimzi/testclients/kafka/KafkaProducerClient.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.testclients.kafka;
 
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
 import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
 import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
 import io.skodjob.datagenerator.DataGenerator;
@@ -12,6 +13,8 @@ import io.strimzi.testclients.common.ClientsInterface;
 import io.strimzi.testclients.common.properties.KafkaProperties;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
 import io.strimzi.testclients.configuration.kafka.KafkaProducerConfiguration;
+import io.strimzi.testclients.utils.AvroMessageUtils;
+import io.strimzi.testclients.utils.JsonMessgeUtils;
 import io.strimzi.testclients.utils.ProtobufMessageUtils;
 import io.strimzi.testclients.tracing.TracingUtil;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -147,6 +150,10 @@ public class KafkaProducerClient implements ClientsInterface {
         } else {
             if (this.configuration.getValueSerializer().equals(ProtobufKafkaSerializer.class.getName())) {
                 message = ProtobufMessageUtils.buildMessageFromJson(configuration);
+            } else if (this.configuration.getValueSerializer().equals(AvroKafkaSerializer.class.getName())) {
+                message = AvroMessageUtils.buildMessageFromJson(configuration);
+            } else if (this.configuration.getValueSerializer().equals(JsonSchemaKafkaSerializer.class.getName())) {
+                message = JsonMessgeUtils.buildMessageFromJson(configuration);
             } else {
                 message = configuration.getMessage() + " - " + numOfMessage;
             }

--- a/clients/src/main/java/io/strimzi/testclients/utils/AvroMessageUtils.java
+++ b/clients/src/main/java/io/strimzi/testclients/utils/AvroMessageUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testclients.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.strimzi.testclients.configuration.kafka.KafkaProducerConfiguration;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class AvroMessageUtils {
+    private AvroMessageUtils() {}
+
+    /**
+     * Builds an Avro {@link GenericRecord} from a JSON message using
+     * the schema provided in the producer configuration.
+     *
+     * <p>This method:
+     * <ul>
+     *     <li>Fetches the Avro schema from the additional producer configuration.</li>
+     *     <li>Parses the schema definition.</li>
+     *     <li>Deserializes the JSON message into a map of field values.</li>
+     *     <li>Populates a {@link GenericRecordBuilder} with the parsed fields.</li>
+     * </ul>
+     * </p>
+     *
+     * @param configuration the Kafka producer configuration containing the
+     *                      message payload and schema configuration
+     * @return a {@link GenericRecord} constructed from the JSON message
+     * @throws RuntimeException if schema parsing or message conversion fails
+     */
+    public static GenericRecord buildMessageFromJson(final KafkaProducerConfiguration configuration) {
+        try {
+            final byte[] avroSchemaBytes = MessageUtils.fetchSchema(configuration.getAdditionalConfig());
+            final Schema schema = new Schema.Parser().parse(new String(avroSchemaBytes, StandardCharsets.UTF_8));
+
+            final GenericRecordBuilder builder = new GenericRecordBuilder(schema);
+            final ObjectMapper mapper = new ObjectMapper();
+            final Map<String, Object> fields = mapper.readValue(configuration.getMessage(), Map.class);
+
+            fields.forEach(builder::set);
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build Avro message", e);
+        }
+    }
+}

--- a/clients/src/main/java/io/strimzi/testclients/utils/JsonMessgeUtils.java
+++ b/clients/src/main/java/io/strimzi/testclients/utils/JsonMessgeUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testclients.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.strimzi.testclients.configuration.kafka.KafkaProducerConfiguration;
+
+public class JsonMessgeUtils {
+
+    private JsonMessgeUtils() {}
+
+    /**
+     * Parses the configured message payload into a {@link JsonNode}.
+     *
+     * <p>This method reads the raw JSON string and converts it
+     * into a Jackson tree model representation.</p>
+     *
+     * @param configuration the Kafka producer configuration containing
+     *                      the JSON message payload
+     * @return the parsed {@link JsonNode}
+     * @throws RuntimeException if the message cannot be parsed as valid JSON
+     */
+    public static JsonNode buildMessageFromJson(final KafkaProducerConfiguration configuration) {
+        try {
+            final ObjectMapper mapper = new ObjectMapper();
+            return mapper.readTree(configuration.getMessage());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build JSON Schema message", e);
+        }
+    }
+}

--- a/clients/src/main/java/io/strimzi/testclients/utils/MessageUtils.java
+++ b/clients/src/main/java/io/strimzi/testclients/utils/MessageUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testclients.utils;
+
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
+import io.strimzi.testclients.configuration.ConfigurationConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Properties;
+
+public class MessageUtils {
+    private MessageUtils() {}
+
+    /**
+     * Fetches the raw schema bytes from Apicurio Registry.
+     *
+     * <p>The schema type is not restricted and may represent any artifact
+     * supported by the registry (only Avro, Protobuf).</p>
+     *
+     * @param config producer additional configuration containing
+     *               Apicurio Registry connection properties
+     *
+     * @return raw bytes of the schema content
+     * @throws IOException if the schema cannot be fetched from the registry
+     */
+    public static byte[] fetchSchema(final Properties config) throws IOException {
+        final URL url = buildSchemaUrl(config);
+        try (final InputStream inputStream = url.openStream()) {
+            return inputStream.readAllBytes();
+        }
+    }
+
+    /**
+     * Builds the Apicurio Registry schema content URL based on the producer configuration.
+     *
+     * <p>The URL format differs depending on the configured Apicurio API version:
+     * <ul>
+     *   <li>v2: {@code /groups/{groupId}/artifacts/{artifactId}/versions/{version}}</li>
+     *   <li>v3: {@code /groups/{groupId}/artifacts/{artifactId}/versions/{version}/content}</li>
+     * </ul>
+     * </p>
+     *
+     * <p>This method is schema-type agnostic and works for any artifact stored
+     * in Apicurio Registry.</p>
+     *
+     * @param config producer additional configuration containing
+     *               Apicurio Registry connection properties
+     *
+     * @return URL pointing to the schema content in Apicurio Registry
+     * @throws MalformedURLException    if the constructed URL is invalid
+     * @throws IllegalArgumentException if the specified API version is not supported
+     */
+    private static URL buildSchemaUrl(final Properties config) throws MalformedURLException {
+        final String registryUrl = config.getProperty(SchemaResolverConfig.REGISTRY_URL);
+        final String groupId = config.getProperty(ConfigurationConstants.REGISTRY_GROUP_ID, ConfigurationConstants.DEFAULT_GROUP_ID);
+        final String artifactId = config.getProperty(ConfigurationConstants.REGISTRY_ARTIFACT_ID);
+        final String version = config.getProperty(ConfigurationConstants.REGISTRY_ARTIFACT_VERSION, ConfigurationConstants.REGISTRY_DEFAULT_ARTIFACT_VERSION);
+        final String apiVersion = config.getProperty(ConfigurationConstants.REGISTRY_API_VERSION, ConfigurationConstants.REGISTRY_DEFAULT_API_VERSION);
+
+        final String urlString;
+        if (ConfigurationConstants.APICURIO_API_V2.equals(apiVersion)) {
+            urlString = String.format("%s/groups/%s/artifacts/%s/versions/%s",
+                registryUrl, groupId, artifactId, version);
+        } else if (ConfigurationConstants.APICURIO_API_V3.equals(apiVersion)) {
+            urlString = String.format("%s/groups/%s/artifacts/%s/versions/%s/content",
+                registryUrl, groupId, artifactId, version);
+        } else {
+            throw new IllegalArgumentException("Unsupported Apicurio Registry API version: " + apiVersion + ". Supported versions are: v2, v3");
+        }
+
+        return URI.create(urlString).toURL();
+    }
+}

--- a/clients/src/main/java/io/strimzi/testclients/utils/ProtobufMessageUtils.java
+++ b/clients/src/main/java/io/strimzi/testclients/utils/ProtobufMessageUtils.java
@@ -8,19 +8,12 @@ import com.google.protobuf.util.JsonFormat;
 import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
 import io.apicurio.registry.serde.protobuf.ProtobufSchemaParser;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
-import io.strimzi.testclients.configuration.ConfigurationConstants;
 import io.strimzi.testclients.configuration.kafka.KafkaProducerConfiguration;
 
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Descriptors.Descriptor;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
 import java.util.Collections;
-import java.util.Properties;
 
 /**
  * Utility class for building Protobuf {@link DynamicMessage} instances from JSON strings.
@@ -47,7 +40,7 @@ public class ProtobufMessageUtils {
      */
     public static DynamicMessage buildMessageFromJson(final KafkaProducerConfiguration configuration) {
         try {
-            final byte[] protoSchemaBytes = fetchSchema(configuration.getAdditionalConfig());
+            final byte[] protoSchemaBytes = MessageUtils.fetchSchema(configuration.getAdditionalConfig());
             final Descriptor descriptor = parseDescriptor(protoSchemaBytes);
 
             // Build DynamicMessage using descriptor defining the message structure
@@ -60,55 +53,6 @@ public class ProtobufMessageUtils {
         }
     }
 
-    /**
-     * Fetches the raw Protobuf schema bytes from Apicurio Registry .
-     *
-     * @param config    producer additional config containing Apicurio Registry connection properties
-     *
-     * @return  raw bytes of the Protobuf schema
-     * @throws IOException  if the schema cannot be fetched from the registry
-     */
-    private static byte[] fetchSchema(final Properties config) throws IOException {
-        final URL url = buildSchemaUrl(config);
-        try (final InputStream inputStream = url.openStream()) {
-            return inputStream.readAllBytes();
-        }
-    }
-
-    /**
-     * Builds the Apicurio Registry schema content URL based on the producer additional config.
-     * URL format differs between API versions:
-     * <ul>
-     *   <li>v2: {@code /apis/registry/v2/groups/{groupId}/artifacts/{artifactId}/versions/{version}}</li>
-     *   <li>v3: {@code /apis/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/{version}/content}</li>
-     * </ul>
-     *
-     * @param config    producer additional config containing Apicurio Registry connection properties
-     *
-     * @return  URL pointing to the schema content in Apicurio Registry
-     * @throws MalformedURLException        if the constructed URL is invalid
-     * @throws IllegalArgumentException     if the specified API version is not supported
-     */
-    private static URL buildSchemaUrl(final Properties config) throws MalformedURLException {
-        final String registryUrl = config.getProperty(ConfigurationConstants.REGISTRY_URL);
-        final String groupId = config.getProperty(ConfigurationConstants.REGISTRY_GROUP_ID, ConfigurationConstants.DEFAULT_GROUP_ID);
-        final String artifactId = config.getProperty(ConfigurationConstants.REGISTRY_ARTIFACT_ID);
-        final String version = config.getProperty(ConfigurationConstants.REGISTRY_ARTIFACT_VERSION, ConfigurationConstants.REGISTRY_DEFAULT_ARTIFACT_VERSION);
-        final String apiVersion = config.getProperty(ConfigurationConstants.REGISTRY_API_VERSION, ConfigurationConstants.REGISTRY_DEFAULT_API_VERSION);
-
-        final String urlString;
-        if (ConfigurationConstants.APICURIO_API_V2.equals(apiVersion)) {
-            urlString = String.format("%s/groups/%s/artifacts/%s/versions/%s",
-                registryUrl, groupId, artifactId, version);
-        } else if (ConfigurationConstants.APICURIO_API_V3.equals(apiVersion)) {
-            urlString = String.format("%s/groups/%s/artifacts/%s/versions/%s/content",
-                registryUrl, groupId, artifactId, version);
-        } else {
-            throw new IllegalArgumentException("Unsupported Apicurio Registry API version: " + apiVersion + ". Supported versions are: v2, v3");
-        }
-
-        return URI.create(urlString).toURL();
-    }
 
     /**
      * Parses raw Protobuf schema bytes into a {@link Descriptor} representing

--- a/clients/src/test/java/io/strimzi/testclients/integration/KafkaClientWithRegistryIT.java
+++ b/clients/src/test/java/io/strimzi/testclients/integration/KafkaClientWithRegistryIT.java
@@ -4,9 +4,11 @@
  */
 package io.strimzi.testclients.integration;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.DynamicMessage;
 import io.apicurio.registry.client.RegistryClientFactory;
 import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
@@ -16,11 +18,13 @@ import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
 import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
 import io.apicurio.registry.serde.config.IdOption;
 import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer;
 import io.apicurio.registry.serde.protobuf.ProtobufKafkaSerializer;
 import io.skodjob.datagenerator.enums.ETemplateType;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
 import io.strimzi.testclients.kafka.KafkaConsumerClient;
 import io.strimzi.testclients.kafka.KafkaProducerClient;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -74,7 +78,7 @@ public class KafkaClientWithRegistryIT extends io.strimzi.testclients.integratio
 
     private String getRegistryConfig() {
         return System.lineSeparator() +
-            ConfigurationConstants.REGISTRY_URL + "=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v2" +
+            SchemaResolverConfig.REGISTRY_URL + "=http://0.0.0.0" + ":" + registry.getMappedPort(8080) + "/apis/registry/v2" +
             System.lineSeparator() +
             SerdeConfig.USE_ID + "=" + IdOption.contentId +
             System.lineSeparator() +
@@ -165,7 +169,7 @@ public class KafkaClientWithRegistryIT extends io.strimzi.testclients.integratio
      * @throws TimeoutException        if message production exceeds the allowed timeout
      */
     @Test
-    void testExchangeProtobuf() throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {
+    void testExchangeFormattedProtobuf() throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {
 
         final String topicName = "test-protobuf";
         final String artifactId = topicName + "-value";
@@ -230,6 +234,180 @@ public class KafkaClientWithRegistryIT extends io.strimzi.testclients.integratio
         Field producedMessages = KafkaProducerClient.class.getDeclaredField("messageSuccessfullySent");
         producedMessages.setAccessible(true);
 
+        assertThat(producedMessages.get(kafkaProducerClient), is(messageCount));
+    }
+
+    /**
+     * Tests producing Avro-formatted messages using Apicurio Schema Registry.
+     *
+     * <p>This test:</p>
+     * <ul>
+     *   <li>Registers an Avro schema artifact in Apicurio Registry.</li>
+     *   <li>Creates a Kafka topic.</li>
+     *   <li>Configures a Kafka producer to use the {@link AvroKafkaSerializer}.</li>
+     *   <li>Generates Avro {@link GenericRecord} messages from a JSON payload.</li>
+     *   <li>Sends a defined number of messages asynchronously.</li>
+     *   <li>Verifies that the produced record value is a {@link GenericRecord}
+     *       and that the expected number of messages were successfully sent.</li>
+     * </ul>
+     *
+     * @throws ExecutionException     if asynchronous message production fails
+     * @throws InterruptedException   if the producer thread is interrupted
+     * @throws NoSuchFieldException   if reflection access to internal state fails
+     * @throws IllegalAccessException if reflection access to internal state fails
+     * @throws TimeoutException       if message production exceeds the allowed timeout
+     */
+    @Test
+    void testExchangeFormattedAvro() throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {
+        final String topicName = "test-avro-plain";
+        final String artifactId = topicName + "-value";
+        final int messageCount = 20;
+        final String message = "{\"name\":\"Bob\",\"age\":30}";
+        final String avroSchema = """
+            {
+              "type": "record",
+              "name": "Person",
+              "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "age", "type": "int"}
+              ]
+            }
+            """;
+
+        RegistryClientOptions options = RegistryClientOptions.create("http://localhost:" + registry.getMappedPort(8080));
+        RegistryClient client = RegistryClientFactory.create(options);
+
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType("AVRO");
+
+        VersionContent content = new VersionContent();
+        content.setContent(avroSchema);
+        content.setContentType("application/json");
+
+        CreateVersion createVersion = new CreateVersion();
+        createVersion.setContent(content);
+        createArtifact.setFirstVersion(createVersion);
+
+        client.groups().byGroupId(ConfigurationConstants.DEFAULT_GROUP_ID).artifacts().post(createArtifact);
+        assertEquals(artifactId, client.groups().byGroupId(ConfigurationConstants.DEFAULT_GROUP_ID).artifacts().byArtifactId(artifactId).get().getArtifactId());
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, kafkaCluster.getBootstrapServers());
+        configuration.put(ConfigurationConstants.TOPIC_ENV, topicName);
+        configuration.put(ConfigurationConstants.MESSAGE_ENV, message);
+        configuration.put(ConfigurationConstants.MESSAGE_COUNT_ENV, String.valueOf(messageCount));
+        configuration.put(ConfigurationConstants.ADDITIONAL_CONFIG_ENV,
+            ConfigurationConstants.REGISTRY_ARTIFACT_ID + "=" + artifactId +
+            System.lineSeparator() +
+            ConfigurationConstants.REGISTRY_GROUP_ID + "=" + ConfigurationConstants.DEFAULT_GROUP_ID +
+            System.lineSeparator() +
+            ConfigurationConstants.REGISTRY_API_VERSION + "=" + ConfigurationConstants.APICURIO_API_V2 +
+            System.lineSeparator() +
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG + "=" + AvroKafkaSerializer.class.getName() +
+            getRegistryConfig()
+        );
+
+        createKafkaTopic(topicName, Map.of(TopicConfig.RETENTION_MS_CONFIG, "604800000"));
+
+        KafkaProducerClient kafkaProducerClient = new KafkaProducerClient(configuration);
+
+        ProducerRecord record = kafkaProducerClient.generateMessage(1);
+        assertInstanceOf(GenericRecord.class, record.value());
+
+        CompletableFuture<Void> future = CompletableFuture.runAsync(kafkaProducerClient::run);
+        future.get(10, TimeUnit.SECONDS);
+
+        Field producedMessages = KafkaProducerClient.class.getDeclaredField("messageSuccessfullySent");
+        producedMessages.setAccessible(true);
+        assertThat(producedMessages.get(kafkaProducerClient), is(messageCount));
+    }
+
+    /**
+     * Tests producing JSON Schema–formatted messages
+     *
+     * <p>This test:</p>
+     * <ul>
+     *   <li>Registers a JSON Schema artifact in Apicurio Registry.</li>
+     *   <li>Creates a Kafka topic.</li>
+     *   <li>Configures a Kafka producer to use the {@link JsonSchemaKafkaSerializer}.</li>
+     *   <li>Generates JSON messages from a raw JSON payload.</li>
+     *   <li>Sends a defined number of messages asynchronously.</li>
+     *   <li>Verifies that the produced record value is a {@link JsonNode}
+     *       and that the expected number of messages were successfully sent.</li>
+     * </ul>
+     *
+     * @throws ExecutionException     if asynchronous message production fails
+     * @throws InterruptedException   if the producer thread is interrupted
+     * @throws NoSuchFieldException   if reflection access to internal state fails
+     * @throws IllegalAccessException if reflection access to internal state fails
+     * @throws TimeoutException       if message production exceeds the allowed timeout
+     */
+    @Test
+    void testExchangeFormattedJsonSchema() throws ExecutionException, InterruptedException, NoSuchFieldException, IllegalAccessException, TimeoutException {
+        final String topicName = "test-json-schema";
+        final String artifactId = topicName + "-value";
+        final int messageCount = 20;
+        final String message = "{\"name\":\"Joe\",\"age\":21}";
+        final String jsonSchema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"}
+              },
+              "required": ["name", "age"]
+            }
+            """;
+
+        RegistryClientOptions options = RegistryClientOptions.create("http://localhost:" + registry.getMappedPort(8080));
+        RegistryClient client = RegistryClientFactory.create(options);
+
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactId(artifactId);
+        createArtifact.setArtifactType("JSON");
+
+        VersionContent content = new VersionContent();
+        content.setContent(jsonSchema);
+        content.setContentType("application/json");
+
+        CreateVersion createVersion = new CreateVersion();
+        createVersion.setContent(content);
+        createArtifact.setFirstVersion(createVersion);
+
+        client.groups().byGroupId(ConfigurationConstants.DEFAULT_GROUP_ID).artifacts().post(createArtifact);
+        assertEquals(artifactId, client.groups().byGroupId(ConfigurationConstants.DEFAULT_GROUP_ID).artifacts().byArtifactId(artifactId).get().getArtifactId());
+
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, kafkaCluster.getBootstrapServers());
+        configuration.put(ConfigurationConstants.TOPIC_ENV, topicName);
+        configuration.put(ConfigurationConstants.MESSAGE_ENV, message);
+        configuration.put(ConfigurationConstants.MESSAGE_COUNT_ENV, String.valueOf(messageCount));
+
+
+        configuration.put(ConfigurationConstants.ADDITIONAL_CONFIG_ENV,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG + "=" + JsonSchemaKafkaSerializer.class.getName() +
+            System.lineSeparator() +
+            SerdeConfig.EXPLICIT_ARTIFACT_ID + "=" + artifactId +
+            System.lineSeparator() +
+            SerdeConfig.EXPLICIT_ARTIFACT_GROUP_ID + "=" + ConfigurationConstants.DEFAULT_GROUP_ID +
+            System.lineSeparator() +
+            getRegistryConfig()
+        );
+
+        createKafkaTopic(topicName, Map.of(TopicConfig.RETENTION_MS_CONFIG, "604800000"));
+
+        KafkaProducerClient kafkaProducerClient = new KafkaProducerClient(configuration);
+
+        ProducerRecord record = kafkaProducerClient.generateMessage(1);
+        assertInstanceOf(JsonNode.class, record.value());
+
+        CompletableFuture<Void> future = CompletableFuture.runAsync(kafkaProducerClient::run);
+        future.get(10, TimeUnit.SECONDS);
+
+        Field producedMessages = KafkaProducerClient.class.getDeclaredField("messageSuccessfullySent");
+        producedMessages.setAccessible(true);
         assertThat(producedMessages.get(kafkaProducerClient), is(messageCount));
     }
 }


### PR DESCRIPTION
Adds support for producing Avro and JSON Schema-encoded messages to Kafka topics using Apicurio Registry schema validation. Extends the existing Protobuf support to cover all three major schema types.

### Changes:

- Added AvroMessageUtils class that fetches the Avro schema from Apicurio Registry and converts a JSON string into a GenericRecord required by AvroKafkaSerializer
- Added JsonMessageUtils class that parses a JSON string into a JsonNode for use with JsonSchemaKafkaSerializer
- Extracted shared schema fetch logic into MessageUtils.fetchSchema() and MessageUtils.buildSchemaUrl(), used by both AvroMessageUtils and ProtobufMessageUtils
- Extended KafkaProducerClient.generateMessage() to detect AvroKafkaSerializer and JsonSchemaKafkaSerializer and delegate to the respective utils
- Added integration tests in KafkaClientWithRegistryIT covering Avro, Protobuf and JSON Schema end-to-end with a containerized Apicurio Registry

### Motivation — why Avro and JSON Schema require different handling
* For Avro, AvroKafkaSerializer requires a GenericRecord — a typed object that carries the schema inside it. AvroMessageUtils does this by fetching the schema from the registry and building the GenericRecord from the JSON payload. The serializer can then extract the schema from the record directly, without needing explicit artifact coordinates.

* For JSON Schema, no typed wrapper equivalent to GenericRecord or DynamicMessage exists — JSON Schema is validation-only. JsonMessageUtils parses the payload into a plain JsonNode, and the serializer resolves the schema via explicit artifact coordinates (EXPLICIT_ARTIFACT_ID + EXPLICIT_ARTIFACT_GROUP_ID) since JsonSchemaParser.supportsExtractSchemaFromData() returns false.

> NOTE: This behaviour was discussed with apicurio dev and this PR takes into account his knowledge on this topic.

### Usage in client builder:
Avro and JSON Schema support is configured entirely through withAdditionalConfig(). The message payload is passed as a JSON string via withMessage() and the utils handle the conversion transparently.
Avro:
```
.withMessage("{\"id\": 1, \"message\": \"verify-avro\"}")
.withAdditionalConfig(
    """
    value.serializer=io.apicurio.registry.serde.avro.AvroKafkaSerializer
    apicurio.registry.url=http://apicurio-app-service.namespace.svc:8080/apis/registry/v2
    apicurio.registry.group-id=default
    apicurio.registry.artifact-id=test-avro-schema
    apicurio.registry.artifact-version=1
    apicurio.registry.find-latest=true
    apicurio.registry.auto-register=false
    """
)
```
JSON Schema:
```
.withMessage("{\"id\": 1, \"message\": \"verify-json\"}")
.withAdditionalConfig(
    """
    value.serializer=io.apicurio.registry.serde.jsonschema.JsonSchemaKafkaSerializer
    apicurio.registry.url=http://apicurio-app-service.namespace.svc:8080/apis/registry/v2
    apicurio.registry.explicit-artifact-id=test-json-schema
    apicurio.registry.explicit-artifact-group-id=default
    apicurio.registry.find-latest=true
    apicurio.registry.auto-register=false
    """
)
```

> You can read more about the serialization issue in SERIALIZATION.md