### PR TITLE
Add missing project info and other things needed for release

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -7,5 +7,9 @@
 <suppressions>
 
     <!-- Note that [/\\] must be used as the path separator for cross-platform support -->
+    <suppress checks=".*"
+              files="io[/\\]strimzi[/\\]testclients[/\\]clients[/\\].*(Builder|Fluent|FluentImpl)\.java"/>
+    <suppress checks=".*"
+              files="io[/\\]strimzi[/\\]testclients[/\\]configuration[/\\].*(Builder|Fluent|FluentImpl)\.java"/>
 
 </suppressions>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -9,6 +9,7 @@
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Test-Clients Admin Client</name>
     <artifactId>admin</artifactId>
 
     <dependencies>

--- a/builders/pom.xml
+++ b/builders/pom.xml
@@ -9,6 +9,7 @@
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Test-Clients Builders</name>
     <artifactId>builders</artifactId>
 
     <dependencies>

--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpConsumerClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpConsumerClient.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class HttpConsumerClient extends HttpClientBase {
     private String clientId;
     private Long pollInterval = 1000L;

--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerClient.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class HttpProducerClient extends HttpClientBase {
     private Long delayMs = 0L;
     private String message;

--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
@@ -8,7 +8,7 @@ import io.strimzi.testclients.configuration.Tracing;
 import io.strimzi.testclients.configuration.TracingBuilder;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class HttpProducerConsumer extends HttpCommon {
     private String producerName;
     private String consumerName;

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaAdminClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaAdminClient.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaAdminClient extends KafkaBaseClient {
     private String configFolderPath;
 

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaBaseClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaBaseClient.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaBaseClient extends KafkaCommon {
     private String name;
 

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClient.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaConsumerClient extends KafkaBaseClient {
     private String clientId;
     private String clientRack;

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerClient.java
@@ -16,7 +16,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaProducerClient extends KafkaBaseClient {
     private String acks;
     private String message;

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
@@ -9,7 +9,7 @@ import io.strimzi.testclients.configuration.TracingBuilder;
 import io.strimzi.testclients.configuration.Transactional;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaProducerConsumer extends KafkaCommon {
     private String producerName;
     private String consumerName;

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClient.java
@@ -15,7 +15,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class KafkaStreamsClient extends KafkaBaseClient {
     private String applicationId;
     private String sourceTopicName;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Image.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Image.java
@@ -6,7 +6,7 @@ package io.strimzi.testclients.configuration;
 
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class Image {
     public static String defaultImage = "quay.io/strimzi-test-clients/test-clients:latest-kafka-4.2.0";
     private String imageName = defaultImage;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/OAuth.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/OAuth.java
@@ -10,7 +10,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class OAuth {
     private String oauthClientId;
     private String oauthClientSecret;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Sasl.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Sasl.java
@@ -10,7 +10,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class Sasl {
     private String saslMechanism;
     private String saslJaasConfig;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Ssl.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Ssl.java
@@ -10,7 +10,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class Ssl {
     private String sslTruststoreCertificate;
     private String sslKeystoreKey;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Tracing.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Tracing.java
@@ -11,7 +11,7 @@ import io.sundr.builder.annotations.Buildable;
 import java.util.ArrayList;
 import java.util.List;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class Tracing {
     private String serviceName;
     private String serviceNameEnvVar;

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Transactional.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Transactional.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.sundr.builder.annotations.Buildable;
 
-@Buildable
+@Buildable(editableEnabled = false)
 public class Transactional {
     private Long messagesPerTransaction = null;
 

--- a/clients-common/pom.xml
+++ b/clients-common/pom.xml
@@ -9,6 +9,7 @@
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Test-Clients Common</name>
     <artifactId>clients-common</artifactId>
 
     <dependencies>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -9,6 +9,7 @@
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
+    <name>Strimzi Test-Clients Implementation</name>
     <artifactId>clients</artifactId>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,37 @@
     <packaging>pom</packaging>
     <version>0.13.0-SNAPSHOT</version>
 
+    <name>Strimzi Test-Clients</name>
+    <description>Test-Clients used for testing message transmission to Kafka and Bridge clusters</description>
+    <url>https://strimzi.io/</url>
+
+    <scm>
+        <connection>scm:git:git://github.com/strimzi/test-clients.git</connection>
+        <developerConnection>scm:git:ssh://github.com:strimzi/test-clients.git</developerConnection>
+        <url>https://github.com/strimzi/test-clients</url>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/strimzi/test-clients/issues</url>
+    </issueManagement>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Strimzi Project Maintainers</name>
+            <email>cncf-strimzi-maintainers@lists.cncf.io</email>
+            <organization>Strimzi</organization>
+            <organizationUrl>https://github.com/strimzi/governance</organizationUrl>
+        </developer>
+    </developers>
+
     <modules>
         <module>tracing</module>
         <module>clients</module>
@@ -32,6 +63,9 @@
         <maven.surefire.version>3.5.2</maven.surefire.version>
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
         <maven-shade.version>3.2.1</maven-shade.version>
+        <maven.source.version>3.2.1</maven.source.version>
+        <maven.jar.version>3.3.0</maven.jar.version>
+
         <log4j.version>2.24.3</log4j.version>
         <sl4j.version>2.0.17</sl4j.version>
 
@@ -89,6 +123,7 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
@@ -295,6 +330,19 @@
                         </configuration>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
During first `mvn deploy` for the release of some version I found that we are missing some of the plugins and info needed for successful release to Sonatype Maven Central. This PR fixes this.