### PR TITLE
Add Javadoc to the project

### DIFF
--- a/admin/src/main/java/io/strimzi/testclients/admin/AdminProperties.java
+++ b/admin/src/main/java/io/strimzi/testclients/admin/AdminProperties.java
@@ -15,6 +15,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+/**
+ * Class used for handling Admin-client related properties.
+ */
 public class AdminProperties {
 
     /**

--- a/admin/src/main/java/io/strimzi/testclients/arguments/CommandInterface.java
+++ b/admin/src/main/java/io/strimzi/testclients/arguments/CommandInterface.java
@@ -6,6 +6,9 @@ package io.strimzi.testclients.arguments;
 
 import java.util.concurrent.Callable;
 
+/**
+ * Default interface for all commands of the admin-client.
+ */
 public interface CommandInterface extends Callable<Integer> {
 
     @Override

--- a/admin/src/main/java/io/strimzi/testclients/arguments/configure/SaslCommand.java
+++ b/admin/src/main/java/io/strimzi/testclients/arguments/configure/SaslCommand.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 
 /**
  * Subcommand for setting up SASL related configuration of admin-client
- * Users can either set "SASL JAAS configuration" or "username & password" for the client
+ * Users can either set "SASL JAAS configuration" or "username and password" for the client
  */
 @CommandLine.Command(name = "sasl")
 public class SaslCommand implements CommandInterface {

--- a/admin/src/main/java/io/strimzi/testclients/constants/Constants.java
+++ b/admin/src/main/java/io/strimzi/testclients/constants/Constants.java
@@ -4,12 +4,30 @@
  */
 package io.strimzi.testclients.constants;
 
+/**
+ * Class for keeping admin-client constants.
+ */
 public interface Constants {
+    /**
+     * Default call timeout in ms.
+     */
     long CALL_TIMEOUT_MS = 30000;
 
+    /**
+     * Name of the truststore file (certificate).
+     */
     String TRUSTSTORE_FILE_NAME = "truststore.crt";
+    /**
+     * Name of the keystore key file.
+     */
     String KEYSTORE_KEY_FILE_NAME = "keystore.key";
+    /**
+     * Name of the keystore cert file.
+     */
     String KEYSTORE_CERT_FILE_NAME = "keystore.crt";
 
+    /**
+     * Option to describe all topics.
+     */
     String ALL_OPTION = "all";
 }

--- a/admin/src/main/java/io/strimzi/testclients/models/KafkaTopicDescription.java
+++ b/admin/src/main/java/io/strimzi/testclients/models/KafkaTopicDescription.java
@@ -6,16 +6,38 @@ package io.strimzi.testclients.models;
 
 import org.apache.kafka.clients.admin.TopicDescription;
 
+/**
+ * Record for storing the Kafka Topic description.
+ *
+ * @param name              name of the Kafka Topic.
+ * @param partitionCount    number of partitions.
+ * @param replicaCount      number of replicas.
+ */
 public record KafkaTopicDescription(String name, int partitionCount, int replicaCount) {
 
+    /**
+     * Gets name of the Kafka Topic.
+     *
+     * @return name of the Kafka Topic.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets number of partitions.
+     *
+     * @return  number of partitions.
+     */
     public int getPartitionCount() {
         return partitionCount;
     }
 
+    /**
+     * Gets number of replicas.
+     *
+     * @return number of replicas.
+     */
     public int getReplicaCount() {
         return replicaCount;
     }

--- a/admin/src/main/java/io/strimzi/testclients/utils/ConfigurationUtils.java
+++ b/admin/src/main/java/io/strimzi/testclients/utils/ConfigurationUtils.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+/**
+ * Class handling the configuration of the admin-client - mainly loading and configuring the configuration file on specified path.
+ */
 public class ConfigurationUtils {
 
     private static final String HOME_DIR = System.getProperty("user.home");
@@ -63,12 +66,20 @@ public class ConfigurationUtils {
 
     /**
      * Check if configuration file exists
+     *
      * @return boolean determining the existence of the config.properties file
      */
     public static boolean configurationFileExists() {
         return configurationFileExists(getConfigFilePath());
     }
 
+    /**
+     * Check if configuration file exists on specific path.
+     *
+     * @param configFilePath    path to config file that should exist.
+     *
+     * @return boolean determining the existence of the config.properties file
+     */
     public static boolean configurationFileExists(String configFilePath) {
         File configFile = new File(configFilePath);
 
@@ -92,6 +103,9 @@ public class ConfigurationUtils {
 
     /**
      * Loads Properties from the config.properties file
+     *
+     * @param configFilePath    path to the configuration file.
+     *
      * @return Properties loaded from the config.properties file
      */
     public static Properties getPropertiesFromConfigurationFile(String configFilePath) {
@@ -109,7 +123,9 @@ public class ConfigurationUtils {
     /**
      * Loads Properties from the configuration file specified by {@code configFilePath}
      * and builds {@link Map} based on it.
+     *
      * @param configFilePath file path to the configuration file
+     *
      * @return {@link Map} with configuration from file
      */
     public static Map<String, String> getMapOfPropertiesFromConfigurationFile(String configFilePath) {

--- a/admin/src/main/java/io/strimzi/testclients/utils/DescribeNodesUtils.java
+++ b/admin/src/main/java/io/strimzi/testclients/utils/DescribeNodesUtils.java
@@ -12,6 +12,9 @@ import org.apache.kafka.common.Node;
 
 import java.util.List;
 
+/**
+ * Class handling the output of describe nodes call, returning the information either as plaintext or as JSON.
+ */
 public class DescribeNodesUtils {
     /**
      * Returns the output of the `node describe` command based on the `--output` option.

--- a/admin/src/main/java/io/strimzi/testclients/utils/DescribeTopicsUtils.java
+++ b/admin/src/main/java/io/strimzi/testclients/utils/DescribeTopicsUtils.java
@@ -10,6 +10,9 @@ import io.strimzi.testclients.models.KafkaTopicDescription;
 
 import java.util.List;
 
+/**
+ * Class handling the output of describe topics call, returning the information either as plaintext or as JSON.
+ */
 public class DescribeTopicsUtils {
 
     /**

--- a/admin/src/main/java/io/strimzi/testclients/utils/FetchOffsetsUtils.java
+++ b/admin/src/main/java/io/strimzi/testclients/utils/FetchOffsetsUtils.java
@@ -12,6 +12,9 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Class handling the output of list offset call, returning the information either as plaintext or as JSON.
+ */
 public class FetchOffsetsUtils {
 
     /**

--- a/clients/src/main/java/io/strimzi/testclients/utils/AvroMessageUtils.java
+++ b/clients/src/main/java/io/strimzi/testclients/utils/AvroMessageUtils.java
@@ -20,14 +20,13 @@ public class AvroMessageUtils {
      * Builds an Avro {@link GenericRecord} from a JSON message using
      * the schema provided in the producer configuration.
      *
-     * <p>This method:
+     * This method:
      * <ul>
      *     <li>Fetches the Avro schema from the additional producer configuration.</li>
      *     <li>Parses the schema definition.</li>
      *     <li>Deserializes the JSON message into a map of field values.</li>
      *     <li>Populates a {@link GenericRecordBuilder} with the parsed fields.</li>
      * </ul>
-     * </p>
      *
      * @param configuration the Kafka producer configuration containing the
      *                      message payload and schema configuration

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <maven.surefire.version>3.5.2</maven.surefire.version>
         <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
         <maven-shade.version>3.2.1</maven-shade.version>
+        <maven.javadoc.version>3.10.0</maven.javadoc.version>
+
         <maven.source.version>3.2.1</maven.source.version>
         <maven.jar.version>3.3.0</maven.jar.version>
 
@@ -344,6 +346,25 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations</sourcepath>
+                            <show>public</show>
+                            <failOnError>true</failOnError>
+                            <failOnWarnings>false</failOnWarnings>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR adds javadoc validation, fixes some of the Javadoc validation erros, but keeps the `failOnWarnings` to false, so the build will not fail on missing Javadocs, it can be fixed in future PRs.