### PR TITLE
Add Make target for changing the release version in the image default in builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PROJECT_NAME = test-clients
 
 DOCKER_TARGETS = docker_build docker_push docker_tag docker_load docker_save docker_delete_archive docker_amend_manifest docker_gha_sign_manifest docker_gha_sbom docker_gha_push_sbom
 
-release: release_examples release_maven release_clients_version release_package
+release: release_examples release_maven release_clients_version release_default_image release_package
 
 next_version:
 	mvn versions:set -DnewVersion=$(shell echo $(NEXT_VERSION) | tr a-z A-Z)
@@ -26,6 +26,10 @@ release_maven:
 
 release_clients_version:
 	echo "$(RELEASE_VERSION)\c" > clients.version
+
+release_default_image:
+	echo "Changing the release version for default image in builders"
+	$(SED) -i 's|\(public static String defaultImage = "quay.io/strimzi-test-clients/test-clients:\)latest\(-[^"]*"\)|\1$(RELEASE_VERSION)\2|' builders/src/main/java/io/strimzi/testclients/configuration/Image.java
 
 release_package:
 	tar -z -cf ./strimzi-test-clients-$(RELEASE_VERSION).tar.gz ./examples


### PR DESCRIPTION
This PR adds Make target (`release_default_image`) for changing the release version from `latest` to `RELEASE_VERSION`, so the builders are using correct image during the RCs and in the GAed builders.
The target is added to the `release` target and is used in the release process.