### PR TITLE
Add Authentication to builders and remove other objects for configuring authn, fix handling of certificates

### DIFF
--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpClientBase.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpClientBase.java
@@ -62,7 +62,7 @@ class HttpClientBase extends HttpCommon {
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.MESSAGE_COUNT_ENV, this.getMessageCount());
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.ENDPOINT_PREFIX_ENV, this.getEndpointPrefix());
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.MESSAGE_TYPE_ENV, this.getMessageType());
-        Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.CA_CRT_ENV, this.getSslTruststoreCertificate());
+        Environment.configureEnvVariableWithValueFromSecretOrSkip(envVars, ConfigurationConstants.CA_CRT_ENV, this.getSslTruststoreCertificate(), "ca.crt");
 
         return new JobBuilder()
             .withNewMetadata()

--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
@@ -29,9 +29,6 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     public void setProducerName(String producerName) {
-        if (producerName == null || producerName.isEmpty()) {
-            throw new IllegalArgumentException("Producer name cannot be empty");
-        }
         this.producerName = producerName;
     }
 
@@ -40,9 +37,6 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     public void setConsumerName(String consumerName) {
-        if (consumerName == null || consumerName.isEmpty()) {
-            throw new IllegalArgumentException("Consumer name cannot be empty");
-        }
         this.consumerName = consumerName;
     }
 
@@ -102,6 +96,10 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     private HttpProducerClient configureProducer() {
+        if (producerName == null || producerName.isEmpty()) {
+            throw new IllegalArgumentException("Producer name cannot be empty");
+        }
+
         Tracing producerTracing = null;
 
         if (getTracing() != null) {
@@ -140,6 +138,10 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     private HttpConsumerClient configureConsumer() {
+        if (consumerName == null || consumerName.isEmpty()) {
+            throw new IllegalArgumentException("Consumer name cannot be empty");
+        }
+
         Tracing consumerTracing = null;
 
         if (getTracing() != null) {

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaAdminClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaAdminClient.java
@@ -54,16 +54,8 @@ public class KafkaAdminClient extends KafkaBaseClient {
             envVars.addAll(this.getTracing().getTracingEnvVars());
         }
 
-        if (this.getOauth() != null && !this.getOauth().getOAuthEnvVars().isEmpty()) {
-            envVars.addAll(this.getOauth().getOAuthEnvVars());
-        }
-
-        if (this.getSasl() != null && !this.getSasl().getSaslEnvVars().isEmpty()) {
-            envVars.addAll(this.getSasl().getSaslEnvVars());
-        }
-
-        if (this.getSsl() != null && !this.getSsl().getSslEnvVar().isEmpty()) {
-            envVars.addAll(this.getSsl().getSslEnvVar());
+        if (this.getAuthentication() != null && !this.getAuthentication().getAuthenticationEnvVars().isEmpty()) {
+            envVars.addAll(this.getAuthentication().getAuthenticationEnvVars());
         }
 
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, this.getBootstrapAddress());

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaBaseClient.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaBaseClient.java
@@ -55,16 +55,8 @@ public class KafkaBaseClient extends KafkaCommon {
             envVars.addAll(this.getTracing().getTracingEnvVars());
         }
 
-        if (this.getOauth() != null && !this.getOauth().getOAuthEnvVars().isEmpty()) {
-            envVars.addAll(this.getOauth().getOAuthEnvVars());
-        }
-
-        if (this.getSasl() != null && !this.getSasl().getSaslEnvVars().isEmpty()) {
-            envVars.addAll(this.getSasl().getSaslEnvVars());
-        }
-
-        if (this.getSsl() != null && !this.getSsl().getSslEnvVar().isEmpty()) {
-            envVars.addAll(this.getSsl().getSslEnvVar());
+        if (this.getAuthentication() != null && !this.getAuthentication().getAuthenticationEnvVars().isEmpty()) {
+            envVars.addAll(this.getAuthentication().getAuthenticationEnvVars());
         }
 
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.BOOTSTRAP_SERVERS_ENV, this.getBootstrapAddress());

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaCommon.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaCommon.java
@@ -5,10 +5,8 @@
 package io.strimzi.testclients.clients.kafka;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.strimzi.testclients.configuration.Authentication;
 import io.strimzi.testclients.configuration.Image;
-import io.strimzi.testclients.configuration.OAuth;
-import io.strimzi.testclients.configuration.Sasl;
-import io.strimzi.testclients.configuration.Ssl;
 import io.strimzi.testclients.configuration.Tracing;
 
 import java.util.List;
@@ -19,9 +17,7 @@ class KafkaCommon {
     private String bootstrapAddress;
 
     private Image image = new Image();
-    private OAuth oauth;
-    private Sasl sasl;
-    private Ssl ssl;
+    private Authentication authentication;
     private Tracing tracing;
 
     private List<EnvVar> additionalEnvVars;
@@ -57,28 +53,12 @@ class KafkaCommon {
         this.image = image;
     }
 
-    public OAuth getOauth() {
-        return oauth;
+    public Authentication getAuthentication() {
+        return authentication;
     }
 
-    public void setOauth(OAuth oauth) {
-        this.oauth = oauth;
-    }
-
-    public Sasl getSasl() {
-        return sasl;
-    }
-
-    public void setSasl(Sasl sasl) {
-        this.sasl = sasl;
-    }
-
-    public Ssl getSsl() {
-        return ssl;
-    }
-
-    public void setSsl(Ssl ssl) {
-        this.ssl = ssl;
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
     }
 
     public Tracing getTracing() {

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
@@ -25,7 +25,7 @@ public class KafkaProducerConsumer extends KafkaCommon {
     private String headers;
 
     private Integer messageCount;
-    private Integer delayMs;
+    private Integer delayMs = 0;
 
     private Transactional transactional;
 
@@ -37,9 +37,6 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     public void setProducerName(String producerName) {
-        if (producerName == null || producerName.isEmpty()) {
-            throw new IllegalArgumentException("Producer name cannot be empty");
-        }
         this.producerName = producerName;
     }
 
@@ -48,9 +45,6 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     public void setConsumerName(String consumerName) {
-        if (consumerName == null || consumerName.isEmpty()) {
-            throw new IllegalArgumentException("Consumer name cannot be empty");
-        }
         this.consumerName = consumerName;
     }
 
@@ -162,6 +156,10 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     private KafkaProducerClient configureProducer() {
+        if (producerName == null || producerName.isEmpty()) {
+            throw new IllegalArgumentException("Producer name cannot be empty");
+        }
+
         Tracing producerTracing = null;
 
         if (getTracing() != null) {
@@ -186,9 +184,7 @@ public class KafkaProducerConsumer extends KafkaCommon {
             .withNamespaceName(getNamespaceName())
             .withBootstrapAddress(getBootstrapAddress())
             .withImage(getImage())
-            .withOauth(getOauth())
-            .withSasl(getSasl())
-            .withSsl(getSsl())
+            .withAuthentication(getAuthentication())
             .withTracing(producerTracing)
             .withAdditionalEnvVars(getAdditionalEnvVars())
             .withAdditionalConfig(getAdditionalConfig())
@@ -204,6 +200,10 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     private KafkaConsumerClient configureConsumer() {
+        if (consumerName == null || consumerName.isEmpty()) {
+            throw new IllegalArgumentException("Consumer name cannot be empty");
+        }
+
         Tracing consumerTracing = null;
 
         if (getTracing() != null) {
@@ -225,10 +225,8 @@ public class KafkaProducerConsumer extends KafkaCommon {
             .withNamespaceName(getNamespaceName())
             .withBootstrapAddress(getBootstrapAddress())
             .withImage(getImage())
-            .withOauth(getOauth())
-            .withSasl(getSasl())
-            .withSsl(getSsl())
             .withTracing(consumerTracing)
+            .withAuthentication(getAuthentication())
             .withAdditionalEnvVars(getAdditionalEnvVars())
             .withAdditionalConfig(getAdditionalConfig())
             .build();

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Authentication.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Authentication.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.testclients.configuration;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.sundr.builder.annotations.Buildable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class for handling authentication related configuration.
+ * Here we can configure everything related to OAuth, TLS, SCRAM-SHA.
+ */
+@Buildable(editableEnabled = false)
+public class Authentication {
+    /**
+     * Common configuration
+     */
+    private String securityProtocol;
+
+    private OAuth oauth;
+    private Sasl sasl;
+    private Ssl ssl;
+
+    public String getSecurityProtocol() {
+        return securityProtocol;
+    }
+
+    public void setSecurityProtocol(String securityProtocol) {
+        this.securityProtocol = securityProtocol;
+    }
+
+    public OAuth getOauth() {
+        return oauth;
+    }
+
+    public void setOauth(OAuth oauth) {
+        this.oauth = oauth;
+    }
+
+    public Sasl getSasl() {
+        return sasl;
+    }
+
+    public void setSasl(Sasl sasl) {
+        this.sasl = sasl;
+    }
+
+    public Ssl getSsl() {
+        return ssl;
+    }
+
+    public void setSsl(Ssl ssl) {
+        this.ssl = ssl;
+    }
+
+    public List<EnvVar> getAuthenticationEnvVars() {
+        List<EnvVar> envVars = new ArrayList<>();
+
+        Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.SECURITY_PROTOCOL_ENV, this.getSecurityProtocol());
+
+        if (oauth != null && !oauth.getOAuthEnvVars().isEmpty()) {
+            envVars.addAll(oauth.getOAuthEnvVars());
+        }
+        if (sasl != null && !sasl.getSaslEnvVars().isEmpty()) {
+            envVars.addAll(sasl.getSaslEnvVars());
+        }
+        if (ssl != null && !ssl.getSslEnvVars().isEmpty()) {
+            envVars.addAll(ssl.getSslEnvVars());
+        }
+
+        return envVars;
+    }
+}

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Environment.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Environment.java
@@ -11,11 +11,47 @@ import java.util.List;
 
 public class Environment {
 
+    /**
+     * Method for creating EnvVar and then updating the list of EnvVars with it - in case that the value is not empty or `null`.
+     *
+     * @param envVarList        current list of EnvVariables.
+     * @param envVariableName   name of the EnvVar.
+     * @param value             value of the EnvVar.
+     */
     public static void configureEnvVariableOrSkip(List<EnvVar> envVarList, String envVariableName, Object value) {
         if (value != null && !String.valueOf(value).isEmpty()) {
             envVarList.add(new EnvVarBuilder()
                 .withName(envVariableName)
                 .withValue(String.valueOf(value))
+                .build()
+            );
+        }
+    }
+
+    /**
+     * Method for creating EnvVar with `valueFrom` Secret - used for example in case of certificates.
+     * The EnvVar list is then updated with this value.
+     *
+     * @param envVarList        current list of EnvVariables.
+     * @param envVariableName   name of the EnvVar.
+     * @param secretName        name of the Secret from which we will take the value.
+     * @param secretFieldName   name of the field which contains the value.
+     */
+    public static void configureEnvVariableWithValueFromSecretOrSkip(
+        List<EnvVar> envVarList,
+        String envVariableName,
+        String secretName,
+        String secretFieldName
+    ) {
+        if (secretName != null && !secretName.isEmpty() && secretFieldName != null && !secretFieldName.isEmpty()) {
+            envVarList.add(new EnvVarBuilder()
+                .withName(envVariableName)
+                .withNewValueFrom()
+                    .withNewSecretKeyRef()
+                        .withName(secretName)
+                        .withKey(secretFieldName)
+                    .endSecretKeyRef()
+                .endValueFrom()
                 .build()
             );
         }

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Ssl.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Ssl.java
@@ -40,12 +40,12 @@ public class Ssl {
         this.sslKeystoreCertificateChain = sslKeystoreCertificateChain;
     }
 
-    public List<EnvVar> getSslEnvVar() {
+    public List<EnvVar> getSslEnvVars() {
         List<EnvVar> envVars = new ArrayList<>();
 
-        Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.CA_CRT_ENV, this.getSslTruststoreCertificate());
-        Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.USER_KEY_ENV, this.getSslKeystoreKey());
-        Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.USER_CRT_ENV, this.getSslKeystoreCertificateChain());
+        Environment.configureEnvVariableWithValueFromSecretOrSkip(envVars, ConfigurationConstants.CA_CRT_ENV, this.getSslTruststoreCertificate(), "ca.crt");
+        Environment.configureEnvVariableWithValueFromSecretOrSkip(envVars, ConfigurationConstants.USER_KEY_ENV, this.getSslKeystoreKey(), "user.key");
+        Environment.configureEnvVariableWithValueFromSecretOrSkip(envVars, ConfigurationConstants.USER_CRT_ENV, this.getSslKeystoreCertificateChain(), "user.crt");
 
         return envVars;
     }

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.http;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
@@ -68,7 +69,13 @@ public class HttpConsumerClientTest {
 
         Job httpConsumerJob = httpConsumerClient.getJob();
         Container container = httpConsumerJob.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> consumerEnvVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         assertThat(httpConsumerJob.getMetadata().getName(), is(name));
         assertThat(httpConsumerJob.getMetadata().getNamespace(), is(namespaceName));
@@ -76,22 +83,24 @@ public class HttpConsumerClientTest {
         assertThat(container.getName(), is(name));
         assertThat(container.getImage(), is(Image.defaultImage));
 
-        assertThat(consumerEnvVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.POLL_INTERVAL_ENV), is(String.valueOf(pollInterval)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.POLL_TIMEOUT_ENV), is(String.valueOf(pollTimeout)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.CA_CRT_ENV), is(sslTruststoreCert));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.CLIENT_ID_ENV), is(clientId));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.GROUP_ID_ENV), is(consumerGroup));
+        assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
+        assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
+        assertThat(envVars.get(ConfigurationConstants.POLL_INTERVAL_ENV), is(String.valueOf(pollInterval)));
+        assertThat(envVars.get(ConfigurationConstants.POLL_TIMEOUT_ENV), is(String.valueOf(pollTimeout)));
+        assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
+        assertThat(envVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
+        assertThat(envVars.get(ConfigurationConstants.CLIENT_ID_ENV), is(clientId));
+        assertThat(envVars.get(ConfigurationConstants.GROUP_ID_ENV), is(consumerGroup));
 
-        assertThat(consumerEnvVars.get("RANDOM"), is("value"));
-        assertThat(consumerEnvVars.get("SOME"), is("thing"));
+        assertThat(envVars.get("RANDOM"), is("value"));
+        assertThat(envVars.get("SOME"), is("thing"));
 
         // these should not exist
-        assertNull(consumerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
+        assertNull(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
+
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(sslTruststoreCert));
+
         assertThat(httpConsumerJob.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(List.of()));
     }
 

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.http;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
@@ -64,7 +65,13 @@ public class HttpProducerClientTest {
 
         Job httpProducerJob = httpProducerClient.getJob();
         Container container = httpProducerJob.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> producerEnvVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         assertThat(httpProducerJob.getMetadata().getName(), is(name));
         assertThat(httpProducerJob.getMetadata().getNamespace(), is(namespaceName));
@@ -72,19 +79,20 @@ public class HttpProducerClientTest {
         assertThat(container.getName(), is(name));
         assertThat(container.getImage(), is(Image.defaultImage));
 
-        assertThat(producerEnvVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
-        assertThat(producerEnvVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.MESSAGE_ENV), is(message));
-        assertThat(producerEnvVars.get(ConfigurationConstants.DELAY_MS_ENV), is(String.valueOf(delayMs)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
-        assertThat(producerEnvVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
-        assertThat(producerEnvVars.get(ConfigurationConstants.CA_CRT_ENV), is(sslTruststoreCert));
-        assertThat(producerEnvVars.get("RANDOM"), is("value"));
-        assertThat(producerEnvVars.get("SOME"), is("thing"));
+        assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
+        assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_ENV), is(message));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is(String.valueOf(delayMs)));
+        assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
+        assertThat(envVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
+        assertThat(envVars.get("RANDOM"), is("value"));
+        assertThat(envVars.get("SOME"), is("thing"));
+
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(sslTruststoreCert));
 
         // these should not exist
-        assertNull(producerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
+        assertNull(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
         assertThat(httpProducerJob.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(List.of()));
     }
 

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.http;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
@@ -73,7 +74,13 @@ public class HttpProducerConsumerTest {
         // Producer part
         Job httpProducerJob = httpProducerConsumer.getProducer().getJob();
         Container container = httpProducerJob.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> producerEnvVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         assertThat(httpProducerJob.getMetadata().getName(), is(producerName));
         assertThat(httpProducerJob.getMetadata().getNamespace(), is(namespaceName));
@@ -81,25 +88,32 @@ public class HttpProducerConsumerTest {
         assertThat(container.getName(), is(producerName));
         assertThat(container.getImage(), is(Image.defaultImage));
 
-        assertThat(producerEnvVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
-        assertThat(producerEnvVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.MESSAGE_ENV), is(message));
-        assertThat(producerEnvVars.get(ConfigurationConstants.DELAY_MS_ENV), is(String.valueOf(delayMs)));
-        assertThat(producerEnvVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
-        assertThat(producerEnvVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
-        assertThat(producerEnvVars.get(ConfigurationConstants.CA_CRT_ENV), is(sslTruststoreCert));
-        assertThat(producerEnvVars.get("RANDOM"), is("value"));
-        assertThat(producerEnvVars.get("SOME"), is("thing"));
+        assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
+        assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_ENV), is(message));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is(String.valueOf(delayMs)));
+        assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
+        assertThat(envVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
+        assertThat(envVars.get("RANDOM"), is("value"));
+        assertThat(envVars.get("SOME"), is("thing"));
+
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(sslTruststoreCert));
 
         // these should not exist
-        assertNull(producerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
+        assertNull(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
         assertThat(httpProducerJob.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(List.of()));
 
         // Consumer part
         Job httpConsumerJob = httpProducerConsumer.getConsumer().getJob();
         container = httpConsumerJob.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> consumerEnvVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         assertThat(httpConsumerJob.getMetadata().getName(), is(consumerName));
         assertThat(httpConsumerJob.getMetadata().getNamespace(), is(namespaceName));
@@ -107,22 +121,23 @@ public class HttpProducerConsumerTest {
         assertThat(container.getName(), is(consumerName));
         assertThat(container.getImage(), is(Image.defaultImage));
 
-        assertThat(consumerEnvVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.POLL_INTERVAL_ENV), is(String.valueOf(delayMs)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.POLL_TIMEOUT_ENV), is(String.valueOf(pollTimeout)));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.CA_CRT_ENV), is(sslTruststoreCert));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.CLIENT_ID_ENV), is(clientId));
-        assertThat(consumerEnvVars.get(ConfigurationConstants.GROUP_ID_ENV), is(consumerGroup));
+        assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
+        assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
+        assertThat(envVars.get(ConfigurationConstants.MESSAGE_COUNT_ENV), is(String.valueOf(messageCount)));
+        assertThat(envVars.get(ConfigurationConstants.POLL_INTERVAL_ENV), is(String.valueOf(delayMs)));
+        assertThat(envVars.get(ConfigurationConstants.POLL_TIMEOUT_ENV), is(String.valueOf(pollTimeout)));
+        assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
+        assertThat(envVars.get(ConfigurationConstants.ENDPOINT_PREFIX_ENV), is(endpointPrefix));
+        assertThat(envVars.get(ConfigurationConstants.CLIENT_ID_ENV), is(clientId));
+        assertThat(envVars.get(ConfigurationConstants.GROUP_ID_ENV), is(consumerGroup));
 
-        assertThat(consumerEnvVars.get("RANDOM"), is("value"));
-        assertThat(consumerEnvVars.get("SOME"), is("thing"));
+        assertThat(envVars.get("RANDOM"), is("value"));
+        assertThat(envVars.get("SOME"), is("thing"));
+
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(sslTruststoreCert));
 
         // these should not exist
-        assertNull(consumerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
+        assertNull(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV));
         assertThat(httpConsumerJob.getSpec().getTemplate().getSpec().getImagePullSecrets(), is(List.of()));
     }
 
@@ -219,26 +234,7 @@ public class HttpProducerConsumerTest {
 
     @Test
     void testEmptyBuilderThrowsExceptionsForImportantFields() {
-        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder().build());
-        assertThat(illegalArgumentException.getMessage(), is("Producer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder()
-            .withProducerName("")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Producer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder()
-            .withProducerName("client")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Consumer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder()
-            .withProducerName("client")
-            .withConsumerName("")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Consumer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder()
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new HttpProducerConsumerBuilder()
             .withProducerName("client")
             .withConsumerName("client")
             .build());

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.kafka;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.strimzi.testclients.configuration.ConfigurationConstants;
@@ -116,13 +117,15 @@ public class KafkaAdminClientTest {
             .withName(name)
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
-            .withNewOauth()
-                .withOauthClientId(clientId)
-                .withOauthAccessToken(accessToken)
-                .withOauthClientSecret(clientSecret)
-                .withOauthRefreshToken(refreshToken)
-                .withOauthTokenEndpointUri(endpointUri)
-            .endOauth()
+            .withNewAuthentication()
+                .withNewOauth()
+                    .withOauthClientId(clientId)
+                    .withOauthAccessToken(accessToken)
+                    .withOauthClientSecret(clientSecret)
+                    .withOauthRefreshToken(refreshToken)
+                    .withOauthTokenEndpointUri(endpointUri)
+                .endOauth()
+            .endAuthentication()
             .build();
 
         Deployment deployment = kafkaAdminClient.getDeployment();
@@ -146,6 +149,7 @@ public class KafkaAdminClientTest {
         String namespaceName = "my-namespace";
         String bootstrapAddress = "localhost:9092";
 
+        String securityProtocol = "SASL_SSL";
         String jaasConfig = "jaas-config";
         String mechanism = "plain";
         String password = "tajne";
@@ -155,12 +159,15 @@ public class KafkaAdminClientTest {
             .withName(name)
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
-            .withNewSasl()
-                .withSaslJaasConfig(jaasConfig)
-                .withSaslMechanism(mechanism)
-                .withSaslPassword(password)
-                .withSaslUserName(username)
-            .endSasl()
+            .withNewAuthentication()
+                .withNewSasl()
+                    .withSaslJaasConfig(jaasConfig)
+                    .withSaslMechanism(mechanism)
+                    .withSaslPassword(password)
+                    .withSaslUserName(username)
+                .endSasl()
+                .withSecurityProtocol(securityProtocol)
+            .endAuthentication()
             .build();
 
         Deployment deployment = kafkaAdminClient.getDeployment();
@@ -168,9 +175,10 @@ public class KafkaAdminClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(5));
+        assertThat(envVars.size(), is(6));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -191,24 +199,33 @@ public class KafkaAdminClientTest {
             .withName(name)
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
-            .withNewSsl()
-                .withSslTruststoreCertificate(truststore)
-                .withSslKeystoreCertificateChain(keystoreCert)
-                .withSslKeystoreKey(keystoreKey)
-            .endSsl()
+            .withNewAuthentication()
+                .withNewSsl()
+                    .withSslTruststoreCertificate(truststore)
+                    .withSslKeystoreCertificateChain(keystoreCert)
+                    .withSslKeystoreKey(keystoreKey)
+                .endSsl()
+            .endAuthentication()
             .build();
 
         Deployment deployment = kafkaAdminClient.getDeployment();
         Container container = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(4));
+        assertThat(envVars.size(), is(1));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.kafka;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ClientType;
@@ -138,13 +139,15 @@ public class KafkaConsumerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewOauth()
-                .withOauthClientId(clientId)
-                .withOauthAccessToken(accessToken)
-                .withOauthClientSecret(clientSecret)
-                .withOauthRefreshToken(refreshToken)
-                .withOauthTokenEndpointUri(endpointUri)
-            .endOauth()
+            .withNewAuthentication()
+                .withNewOauth()
+                    .withOauthClientId(clientId)
+                    .withOauthAccessToken(accessToken)
+                    .withOauthClientSecret(clientSecret)
+                    .withOauthRefreshToken(refreshToken)
+                    .withOauthTokenEndpointUri(endpointUri)
+                .endOauth()
+            .endAuthentication()
             .build();
 
         Job job = kafkaConsumerClient.getJob();
@@ -171,6 +174,7 @@ public class KafkaConsumerClientTest {
         String bootstrapAddress = "localhost:9092";
         String topicName = "my-topic";
 
+        String securityProtocol = "SASL_SSL";
         String jaasConfig = "jaas-config";
         String mechanism = "plain";
         String password = "tajne";
@@ -181,12 +185,15 @@ public class KafkaConsumerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSasl()
-                .withSaslJaasConfig(jaasConfig)
-                .withSaslMechanism(mechanism)
-                .withSaslPassword(password)
-                .withSaslUserName(username)
-            .endSasl()
+            .withNewAuthentication()
+                .withNewSasl()
+                    .withSaslJaasConfig(jaasConfig)
+                    .withSaslMechanism(mechanism)
+                    .withSaslPassword(password)
+                    .withSaslUserName(username)
+                .endSasl()
+                .withSecurityProtocol(securityProtocol)
+            .endAuthentication()
             .build();
 
         Job job = kafkaConsumerClient.getJob();
@@ -194,11 +201,12 @@ public class KafkaConsumerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(7));
+        assertThat(envVars.size(), is(8));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -221,26 +229,35 @@ public class KafkaConsumerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSsl()
-                .withSslTruststoreCertificate(truststore)
-                .withSslKeystoreCertificateChain(keystoreCert)
-                .withSslKeystoreKey(keystoreKey)
-            .endSsl()
+            .withNewAuthentication()
+                .withNewSsl()
+                    .withSslTruststoreCertificate(truststore)
+                    .withSslKeystoreCertificateChain(keystoreCert)
+                    .withSslKeystoreKey(keystoreKey)
+                .endSsl()
+            .endAuthentication()
             .build();
 
         Job job = kafkaConsumerClient.getJob();
         Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(3));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.kafka;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ClientType;
@@ -148,13 +149,15 @@ public class KafkaProducerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewOauth()
-                .withOauthClientId(clientId)
-                .withOauthAccessToken(accessToken)
-                .withOauthClientSecret(clientSecret)
-                .withOauthRefreshToken(refreshToken)
-                .withOauthTokenEndpointUri(endpointUri)
-            .endOauth()
+            .withNewAuthentication()
+                .withNewOauth()
+                    .withOauthClientId(clientId)
+                    .withOauthAccessToken(accessToken)
+                    .withOauthClientSecret(clientSecret)
+                    .withOauthRefreshToken(refreshToken)
+                    .withOauthTokenEndpointUri(endpointUri)
+                .endOauth()
+            .endAuthentication()
             .build();
 
         Job job = kafkaProducerClient.getJob();
@@ -181,6 +184,7 @@ public class KafkaProducerClientTest {
         String bootstrapAddress = "localhost:9092";
         String topicName = "my-topic";
 
+        String securityProtocol = "SASL_SSL";
         String jaasConfig = "jaas-config";
         String mechanism = "plain";
         String password = "tajne";
@@ -191,12 +195,15 @@ public class KafkaProducerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSasl()
-                .withSaslJaasConfig(jaasConfig)
-                .withSaslMechanism(mechanism)
-                .withSaslPassword(password)
-                .withSaslUserName(username)
-            .endSasl()
+            .withNewAuthentication()
+                .withNewSasl()
+                    .withSaslJaasConfig(jaasConfig)
+                    .withSaslMechanism(mechanism)
+                    .withSaslPassword(password)
+                    .withSaslUserName(username)
+                .endSasl()
+                .withSecurityProtocol(securityProtocol)
+            .endAuthentication()
             .build();
 
         Job job = kafkaProducerClient.getJob();
@@ -204,11 +211,12 @@ public class KafkaProducerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(7));
+        assertThat(envVars.size(), is(8));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -231,26 +239,36 @@ public class KafkaProducerClientTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSsl()
-                .withSslTruststoreCertificate(truststore)
-                .withSslKeystoreCertificateChain(keystoreCert)
-                .withSslKeystoreKey(keystoreKey)
-            .endSsl()
+            .withNewAuthentication()
+                .withNewSsl()
+                    .withSslTruststoreCertificate(truststore)
+                    .withSslKeystoreCertificateChain(keystoreCert)
+                    .withSslKeystoreKey(keystoreKey)
+                .endSsl()
+            .endAuthentication()
             .build();
 
         Job job = kafkaProducerClient.getJob();
         Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(3));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.kafka;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ClientType;
@@ -196,13 +197,15 @@ public class KafkaProducerConsumerTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewOauth()
-                .withOauthClientId(clientId)
-                .withOauthAccessToken(accessToken)
-                .withOauthClientSecret(clientSecret)
-                .withOauthRefreshToken(refreshToken)
-                .withOauthTokenEndpointUri(endpointUri)
-            .endOauth()
+            .withNewAuthentication()
+                .withNewOauth()
+                    .withOauthClientId(clientId)
+                    .withOauthAccessToken(accessToken)
+                    .withOauthClientSecret(clientSecret)
+                    .withOauthRefreshToken(refreshToken)
+                    .withOauthTokenEndpointUri(endpointUri)
+                .endOauth()
+            .endAuthentication()
             .build();
 
         // Producer part
@@ -211,7 +214,7 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(8));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
@@ -228,7 +231,7 @@ public class KafkaProducerConsumerTest {
         envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(8));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
@@ -248,6 +251,7 @@ public class KafkaProducerConsumerTest {
         String bootstrapAddress = "localhost:9092";
         String topicName = "my-topic";
 
+        String securityProtocol = "SASL_SSL";
         String jaasConfig = "jaas-config";
         String mechanism = "plain";
         String password = "tajne";
@@ -259,12 +263,15 @@ public class KafkaProducerConsumerTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSasl()
-                .withSaslJaasConfig(jaasConfig)
-                .withSaslMechanism(mechanism)
-                .withSaslPassword(password)
-                .withSaslUserName(username)
-            .endSasl()
+            .withNewAuthentication()
+                .withNewSasl()
+                    .withSaslJaasConfig(jaasConfig)
+                    .withSaslMechanism(mechanism)
+                    .withSaslPassword(password)
+                    .withSaslUserName(username)
+                .endSasl()
+                .withSecurityProtocol(securityProtocol)
+            .endAuthentication()
             .build();
 
         // Producer part
@@ -273,11 +280,13 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(7));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is("0"));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -289,11 +298,13 @@ public class KafkaProducerConsumerTest {
         envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(7));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is("0"));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -318,42 +329,60 @@ public class KafkaProducerConsumerTest {
             .withNamespaceName(namespaceName)
             .withBootstrapAddress(bootstrapAddress)
             .withTopicName(topicName)
-            .withNewSsl()
-                .withSslTruststoreCertificate(truststore)
-                .withSslKeystoreCertificateChain(keystoreCert)
-                .withSslKeystoreKey(keystoreKey)
-            .endSsl()
+            .withNewAuthentication()
+                .withNewSsl()
+                    .withSslTruststoreCertificate(truststore)
+                    .withSslKeystoreCertificateChain(keystoreCert)
+                    .withSslKeystoreKey(keystoreKey)
+                .endSsl()
+            .endAuthentication()
             .build();
 
         // Producer part
         Job job = kafkaProducerConsumer.getProducer().getJob();
         Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(4));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is("0"));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
 
         // Consumer part
         job = kafkaProducerConsumer.getConsumer().getJob();
         container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(4));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is("0"));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
     }
 
     @Test
@@ -387,7 +416,7 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(5));
+        assertThat(envVars.size(), is(6));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
@@ -401,7 +430,7 @@ public class KafkaProducerConsumerTest {
         envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(5));
+        assertThat(envVars.size(), is(6));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
@@ -437,10 +466,11 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(4));
+        assertThat(envVars.size(), is(5));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
+        assertThat(envVars.get(ConfigurationConstants.DELAY_MS_ENV), is("0"));
 
         assertThat(envVars.get(ConfigurationConstants.MESSAGES_PER_TRANSACTION_ENV), is(String.valueOf(messagesPerTransaction)));
 
@@ -454,32 +484,7 @@ public class KafkaProducerConsumerTest {
 
     @Test
     void testBuilderThrowsExceptionsInCaseOfMissingFields() {
-        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder().build());
-        assertThat(illegalArgumentException.getMessage(), is("Producer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
-            .withProducerName("")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Producer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
-            .withProducerName("my-producer")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Consumer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
-            .withProducerName("my-producer")
-            .withConsumerName("")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Consumer name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
-            .withProducerName("my-producer")
-            .withConsumerName("my-consumer")
-            .build());
-        assertThat(illegalArgumentException.getMessage(), is("Topic name cannot be empty"));
-
-        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new KafkaProducerConsumerBuilder()
             .withProducerName("my-producer")
             .withConsumerName("my-consumer")
             .withTopicName("")

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
@@ -7,6 +7,7 @@ package io.strimzi.testclients.clients.kafka;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.strimzi.testclients.configuration.ClientType;
@@ -140,13 +141,15 @@ public class KafkaStreamsClientTest {
             .withApplicationId(applicationId)
             .withSourceTopicName(sourceTopicName)
             .withTargetTopicName(targetTopicName)
-            .withNewOauth()
-                .withOauthClientId(clientId)
-                .withOauthAccessToken(accessToken)
-                .withOauthClientSecret(clientSecret)
-                .withOauthRefreshToken(refreshToken)
-                .withOauthTokenEndpointUri(endpointUri)
-            .endOauth()
+            .withNewAuthentication()
+                .withNewOauth()
+                    .withOauthClientId(clientId)
+                    .withOauthAccessToken(accessToken)
+                    .withOauthClientSecret(clientSecret)
+                    .withOauthRefreshToken(refreshToken)
+                    .withOauthTokenEndpointUri(endpointUri)
+                .endOauth()
+            .endAuthentication()
             .build();
 
         Job job = kafkaStreamsClient.getJob();
@@ -177,6 +180,7 @@ public class KafkaStreamsClientTest {
         String sourceTopicName = "source-topic";
         String targetTopicName = "target-topic";
 
+        String securityProtocol = "SASL_SSL";
         String jaasConfig = "jaas-config";
         String mechanism = "plain";
         String password = "tajne";
@@ -189,12 +193,15 @@ public class KafkaStreamsClientTest {
             .withApplicationId(applicationId)
             .withSourceTopicName(sourceTopicName)
             .withTargetTopicName(targetTopicName)
-            .withNewSasl()
-                .withSaslJaasConfig(jaasConfig)
-                .withSaslMechanism(mechanism)
-                .withSaslPassword(password)
-                .withSaslUserName(username)
-            .endSasl()
+            .withNewAuthentication()
+                .withNewSasl()
+                    .withSaslJaasConfig(jaasConfig)
+                    .withSaslMechanism(mechanism)
+                    .withSaslPassword(password)
+                    .withSaslUserName(username)
+                .endSasl()
+                .withSecurityProtocol(securityProtocol)
+            .endAuthentication()
             .build();
 
         Job job = kafkaStreamsClient.getJob();
@@ -202,13 +209,14 @@ public class KafkaStreamsClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(9));
+        assertThat(envVars.size(), is(10));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaStreams.name()));
         assertThat(envVars.get(ConfigurationConstants.APPLICATION_ID_ENV), is(applicationId));
         assertThat(envVars.get(ConfigurationConstants.SOURCE_TOPIC_ENV), is(sourceTopicName));
         assertThat(envVars.get(ConfigurationConstants.TARGET_TOPIC_ENV), is(targetTopicName));
 
+        assertThat(envVars.get(ConfigurationConstants.SECURITY_PROTOCOL_ENV), is(securityProtocol));
         assertThat(envVars.get(ConfigurationConstants.SASL_JAAS_CONFIG_ENV), is(jaasConfig));
         assertThat(envVars.get(ConfigurationConstants.SASL_MECHANISM_ENV), is(mechanism));
         assertThat(envVars.get(ConfigurationConstants.USER_NAME_ENV), is(username));
@@ -235,28 +243,37 @@ public class KafkaStreamsClientTest {
             .withApplicationId(applicationId)
             .withSourceTopicName(sourceTopicName)
             .withTargetTopicName(targetTopicName)
-            .withNewSsl()
-                .withSslTruststoreCertificate(truststore)
-                .withSslKeystoreCertificateChain(keystoreCert)
-                .withSslKeystoreKey(keystoreKey)
-            .endSsl()
+            .withNewAuthentication()
+                .withNewSsl()
+                    .withSslTruststoreCertificate(truststore)
+                    .withSslKeystoreCertificateChain(keystoreCert)
+                    .withSslKeystoreKey(keystoreKey)
+                .endSsl()
+            .endAuthentication()
             .build();
 
         Job job = kafkaStreamsClient.getJob();
         Container container = job.getSpec().getTemplate().getSpec().getContainers().get(0);
-        Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+        Map<String, String> envVars = container.getEnv().stream()
+            .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        Map<String, EnvVarSource> envVarsWithValueFrom = container.getEnv().stream()
+            .filter(e -> e.getValueFrom() != null)
+            .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValueFrom));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(8));
+        assertThat(envVars.size(), is(5));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaStreams.name()));
         assertThat(envVars.get(ConfigurationConstants.APPLICATION_ID_ENV), is(applicationId));
         assertThat(envVars.get(ConfigurationConstants.SOURCE_TOPIC_ENV), is(sourceTopicName));
         assertThat(envVars.get(ConfigurationConstants.TARGET_TOPIC_ENV), is(targetTopicName));
 
-        assertThat(envVars.get(ConfigurationConstants.CA_CRT_ENV), is(truststore));
-        assertThat(envVars.get(ConfigurationConstants.USER_CRT_ENV), is(keystoreCert));
-        assertThat(envVars.get(ConfigurationConstants.USER_KEY_ENV), is(keystoreKey));
+        assertThat(envVarsWithValueFrom.size(), is(3));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.CA_CRT_ENV).getSecretKeyRef().getName(), is(truststore));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_CRT_ENV).getSecretKeyRef().getName(), is(keystoreCert));
+        assertThat(envVarsWithValueFrom.get(ConfigurationConstants.USER_KEY_ENV).getSecretKeyRef().getName(), is(keystoreKey));
     }
 
     @Test

--- a/clients-common/src/main/java/io/strimzi/testclients/configuration/ConfigurationConstants.java
+++ b/clients-common/src/main/java/io/strimzi/testclients/configuration/ConfigurationConstants.java
@@ -74,6 +74,7 @@ public interface ConfigurationConstants {
      * Kafka basic env variables
      */
     String BOOTSTRAP_SERVERS_ENV = "BOOTSTRAP_SERVERS";
+    String SECURITY_PROTOCOL_ENV = "SECURITY_PROTOCOL";
     String SASL_JAAS_CONFIG_ENV = "SASL_JAAS_CONFIG";
     String USER_NAME_ENV = "USER_NAME";
     String USER_PASSWORD_ENV = "USER_PASSWORD";

--- a/clients-common/src/main/java/io/strimzi/testclients/configuration/kafka/KafkaClientsConfiguration.java
+++ b/clients-common/src/main/java/io/strimzi/testclients/configuration/kafka/KafkaClientsConfiguration.java
@@ -26,6 +26,7 @@ import static io.strimzi.testclients.configuration.ConfigurationConstants.OAUTH_
 import static io.strimzi.testclients.configuration.ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV;
 import static io.strimzi.testclients.configuration.ConfigurationConstants.SASL_JAAS_CONFIG_ENV;
 import static io.strimzi.testclients.configuration.ConfigurationConstants.SASL_MECHANISM_ENV;
+import static io.strimzi.testclients.configuration.ConfigurationConstants.SECURITY_PROTOCOL_ENV;
 import static io.strimzi.testclients.configuration.ConfigurationConstants.TRACING_TYPE_ENV;
 import static io.strimzi.testclients.configuration.ConfigurationConstants.USER_CRT_ENV;
 import static io.strimzi.testclients.configuration.ConfigurationConstants.USER_KEY_ENV;
@@ -36,6 +37,7 @@ public class KafkaClientsConfiguration {
     private final String bootstrapServers;
     private final long delayMs;
     private final int messageCount;
+    private final String securityProtocol;
     private final String sslTruststoreCertificate;
     private final String sslKeystoreKey;
     private final String sslKeystoreCertificateChain;
@@ -56,6 +58,7 @@ public class KafkaClientsConfiguration {
         this.bootstrapServers = map.get(BOOTSTRAP_SERVERS_ENV);
         this.delayMs = parseLongOrDefault(map.get(DELAY_MS_ENV), DEFAULT_DELAY_MS);
         this.messageCount = parseIntOrDefault(map.get(MESSAGE_COUNT_ENV), DEFAULT_MESSAGES_COUNT);
+        this.securityProtocol = map.get(SECURITY_PROTOCOL_ENV);
         this.sslTruststoreCertificate = map.get(CA_CRT_ENV);
         this.sslKeystoreKey = map.get(USER_KEY_ENV);
         this.sslKeystoreCertificateChain = map.get(USER_CRT_ENV);
@@ -84,6 +87,10 @@ public class KafkaClientsConfiguration {
 
     public int getMessageCount() {
         return messageCount;
+    }
+
+    public String getSecurityProtocol() {
+        return securityProtocol;
     }
 
     public String getSslTruststoreCertificate() {
@@ -175,6 +182,7 @@ public class KafkaClientsConfiguration {
         return "bootstrapServers='" + this.getBootstrapServers() + "',\n" +
             "delayMs='" + this.getDelayMs() + "',\n" +
             "messageCount='" + this.getMessageCount() + "',\n" +
+            "securityProtocol='" + this.getSecurityProtocol() + "',\n" +
             "sslTruststoreCertificate='" + sslTruststoreCertificate + "',\n" +
             "sslKeystoreKey='" + sslKeystoreKey + "',\n" +
             "sslKeystoreCertificateChain='" + sslKeystoreCertificateChain + "',\n" +

--- a/clients-common/src/main/java/io/strimzi/testclients/properties/BasicKafkaProperties.java
+++ b/clients-common/src/main/java/io/strimzi/testclients/properties/BasicKafkaProperties.java
@@ -36,6 +36,10 @@ public class BasicKafkaProperties {
     public static Properties updatePropertiesWithSecurityConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
         properties = updatePropertiesWithTlsConfiguration(properties, configuration);
 
+        if (configuration.getSecurityProtocol() != null && !configuration.getSecurityProtocol().isEmpty()) {
+            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, configuration.getSecurityProtocol());
+        }
+
         if (shouldUpdatePropertiesWithSaslConfig(configuration)) {
             properties = updatePropertiesWithSaslConfiguration(properties, configuration);
         }
@@ -48,7 +52,8 @@ public class BasicKafkaProperties {
 
     public static Properties updatePropertiesWithTlsConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
         if (configuration.getSslTruststoreCertificate() != null) {
-            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.toString());
+            maybeUpdateSecurityProtocol(properties, configuration, SecurityProtocol.SSL.toString());
+
             properties.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM");
             properties.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, configuration.getSslTruststoreCertificate());
         }
@@ -64,8 +69,9 @@ public class BasicKafkaProperties {
 
     public static Properties updatePropertiesWithSaslConfiguration(Properties properties, KafkaClientsConfiguration configuration) {
         SaslType saslType = SaslType.getFromString(configuration.getSaslMechanism());
-        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.toString());
         properties.put(SaslConfigs.SASL_MECHANISM, saslType.getKafkaProperty());
+
+        maybeUpdateSecurityProtocol(properties, configuration, SecurityProtocol.SASL_SSL.toString());
 
         String saslJaasConfig = configuration.getSaslJaasConfig();
 
@@ -87,13 +93,21 @@ public class BasicKafkaProperties {
 
     public static Properties updatePropertiesWithOauthConfig(Properties properties, KafkaClientsConfiguration configuration) {
         properties.put(SaslConfigs.SASL_JAAS_CONFIG, "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
-        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL".equals(properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
         properties.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
+
+        maybeUpdateSecurityProtocol(properties, configuration, "SSL".equals(properties.getProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)) ? "SASL_SSL" : "SASL_PLAINTEXT");
+
         if (!(configuration.getAdditionalConfig().containsKey(SaslConfigs.SASL_MECHANISM) && configuration.getAdditionalConfig().getProperty(SaslConfigs.SASL_MECHANISM).equals("PLAIN"))) {
             properties.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, configuration.getSaslLoginCallbackClass());
         }
 
         return properties;
+    }
+
+    private static void maybeUpdateSecurityProtocol(Properties properties, KafkaClientsConfiguration configuration, String securityProtocol) {
+        if (configuration.getSecurityProtocol() == null || configuration.getSecurityProtocol().isEmpty()) {
+            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol);
+        }
     }
 
     public static boolean shouldUpdatePropertiesWithSaslConfig(KafkaClientsConfiguration configuration) {


### PR DESCRIPTION
This PR does several things:

- adds `Authentication` class for handling authn related configuration for SSL, SASL, OAuth
- adds `securityProtocol` to the authn part, it adds new env variable and handling of the security protocol as it wasn't handled until now
- moves verification of consumer/producer name in both `HttpProducerConsumer` and `KafkaProducerConsumer` to part where we are actually getting the producer/consumer, not to the builder
- changes tests to reflect the changes
- removes `Ssl`, `Sasl, and `OAuth` classes for handling related security configuration - it was a bad design in case that we want to configure more things from more these classes -> having one class (`Authentication`) for handling everything is better in terms of UX