### PR TITLE
Fix outdated data in `HttpProducerConsumer` and `KafkaProducerConsumer`

### DIFF
--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
@@ -21,9 +21,6 @@ public class HttpProducerConsumer extends HttpCommon {
 
     private Integer delayMs = 0;
 
-    private HttpProducerClient httpProducerClient;
-    private HttpConsumerClient httpConsumerClient;
-
     public String getProducerName() {
         return producerName;
     }
@@ -89,13 +86,6 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     public HttpProducerClient getProducer() {
-        if (httpProducerClient == null) {
-            httpProducerClient = configureProducer();
-        }
-        return httpProducerClient;
-    }
-
-    private HttpProducerClient configureProducer() {
         if (producerName == null || producerName.isEmpty()) {
             throw new IllegalArgumentException("Producer name cannot be empty");
         }
@@ -130,14 +120,6 @@ public class HttpProducerConsumer extends HttpCommon {
     }
 
     public HttpConsumerClient getConsumer() {
-        if (httpConsumerClient == null) {
-            httpConsumerClient = configureConsumer();
-        }
-
-        return httpConsumerClient;
-    }
-
-    private HttpConsumerClient configureConsumer() {
         if (consumerName == null || consumerName.isEmpty()) {
             throw new IllegalArgumentException("Consumer name cannot be empty");
         }

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
@@ -29,9 +29,6 @@ public class KafkaProducerConsumer extends KafkaCommon {
 
     private Transactional transactional;
 
-    private KafkaProducerClient kafkaProducerClient;
-    private KafkaConsumerClient kafkaConsumerClient;
-
     public String getProducerName() {
         return producerName;
     }
@@ -148,14 +145,6 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     public KafkaProducerClient getProducer() {
-        if (kafkaProducerClient == null) {
-            kafkaProducerClient = configureProducer();
-        }
-
-        return kafkaProducerClient;
-    }
-
-    private KafkaProducerClient configureProducer() {
         if (producerName == null || producerName.isEmpty()) {
             throw new IllegalArgumentException("Producer name cannot be empty");
         }
@@ -192,14 +181,6 @@ public class KafkaProducerConsumer extends KafkaCommon {
     }
 
     public KafkaConsumerClient getConsumer() {
-        if (kafkaConsumerClient == null) {
-            kafkaConsumerClient = configureConsumer();
-        }
-
-        return kafkaConsumerClient;
-    }
-
-    private KafkaConsumerClient configureConsumer() {
         if (consumerName == null || consumerName.isEmpty()) {
             throw new IllegalArgumentException("Consumer name cannot be empty");
         }


### PR DESCRIPTION
Originally, it was intention to not create the clients inside `HttpProducerConsumer` and `KafkaProducerConsumer` from scratch every time and create an instance - which could be reused.
However, in case that we use the same clients' builders through tests and we are using them multiple times, in case of change in the builder will the whole client remain the same - together with the Job. We would have to implement some "reconfiguration" method, which seems to me to be an overkill. So instead, I'm fixing this behavior by removing the instances of clients from the `HttpProducerConsumer` and `KafkaProducerConsumer` classes.