### PR TITLE
Add possibility to specify additional OAuth env variables

### DIFF
--- a/builders/src/main/java/io/strimzi/testclients/configuration/OAuth.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/OAuth.java
@@ -17,6 +17,7 @@ public class OAuth {
     private String oauthAccessToken;
     private String oauthRefreshToken;
     private String oauthTokenEndpointUri;
+    private List<EnvVar> additionalOAuthEnvVars;
 
     public String getOauthClientId() {
         return oauthClientId;
@@ -58,6 +59,14 @@ public class OAuth {
         this.oauthTokenEndpointUri = oauthTokenEndpointUri;
     }
 
+    public List<EnvVar> getAdditionalOAuthEnvVars() {
+        return additionalOAuthEnvVars;
+    }
+
+    public void setAdditionalOAuthEnvVars(List<EnvVar> additionalOAuthEnvVars) {
+        this.additionalOAuthEnvVars = additionalOAuthEnvVars;
+    }
+
     public List<EnvVar> getOAuthEnvVars() {
         List<EnvVar> envVars = new ArrayList<>();
 
@@ -66,6 +75,10 @@ public class OAuth {
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.OAUTH_ACCESS_TOKEN_ENV, this.getOauthAccessToken());
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV, this.getOauthRefreshToken());
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV, this.getOauthTokenEndpointUri());
+
+        if (additionalOAuthEnvVars != null && !additionalOAuthEnvVars.isEmpty()) {
+            envVars.addAll(additionalOAuthEnvVars);
+        }
 
         return envVars;
     }

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
@@ -112,6 +112,10 @@ public class KafkaAdminClientTest {
         String clientSecret = "client-secret";
         String refreshToken = "my-refresh-token";
         String endpointUri = "localhost:8080";
+        EnvVar oauthEnvVar = new EnvVarBuilder()
+            .withName("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM")
+            .withValue("ARNOST")
+            .build();
 
         KafkaAdminClient kafkaAdminClient = new KafkaAdminClientBuilder()
             .withName(name)
@@ -124,6 +128,7 @@ public class KafkaAdminClientTest {
                     .withOauthClientSecret(clientSecret)
                     .withOauthRefreshToken(refreshToken)
                     .withOauthTokenEndpointUri(endpointUri)
+                    .withAdditionalOAuthEnvVars(oauthEnvVar)
                 .endOauth()
             .endAuthentication()
             .build();
@@ -133,7 +138,7 @@ public class KafkaAdminClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(8));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
 
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_ID_ENV), is(clientId));
@@ -141,6 +146,7 @@ public class KafkaAdminClientTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
@@ -133,6 +133,10 @@ public class KafkaConsumerClientTest {
         String clientSecret = "client-secret";
         String refreshToken = "my-refresh-token";
         String endpointUri = "localhost:8080";
+        EnvVar oauthEnvVar = new EnvVarBuilder()
+            .withName("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM")
+            .withValue("ARNOST")
+            .build();
 
         KafkaConsumerClient kafkaConsumerClient = new KafkaConsumerClientBuilder()
             .withName(name)
@@ -146,6 +150,7 @@ public class KafkaConsumerClientTest {
                     .withOauthClientSecret(clientSecret)
                     .withOauthRefreshToken(refreshToken)
                     .withOauthTokenEndpointUri(endpointUri)
+                    .withAdditionalOAuthEnvVars(oauthEnvVar)
                 .endOauth()
             .endAuthentication()
             .build();
@@ -155,7 +160,7 @@ public class KafkaConsumerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(8));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
@@ -165,6 +170,7 @@ public class KafkaConsumerClientTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
@@ -143,6 +143,10 @@ public class KafkaProducerClientTest {
         String clientSecret = "client-secret";
         String refreshToken = "my-refresh-token";
         String endpointUri = "localhost:8080";
+        EnvVar oauthEnvVar = new EnvVarBuilder()
+            .withName("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM")
+            .withValue("ARNOST")
+            .build();
 
         KafkaProducerClient kafkaProducerClient = new KafkaProducerClientBuilder()
             .withName(name)
@@ -156,6 +160,7 @@ public class KafkaProducerClientTest {
                     .withOauthClientSecret(clientSecret)
                     .withOauthRefreshToken(refreshToken)
                     .withOauthTokenEndpointUri(endpointUri)
+                    .withAdditionalOAuthEnvVars(oauthEnvVar)
                 .endOauth()
             .endAuthentication()
             .build();
@@ -165,7 +170,7 @@ public class KafkaProducerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(8));
+        assertThat(envVars.size(), is(9));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
@@ -175,6 +180,7 @@ public class KafkaProducerClientTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
@@ -190,6 +190,10 @@ public class KafkaProducerConsumerTest {
         String clientSecret = "client-secret";
         String refreshToken = "my-refresh-token";
         String endpointUri = "localhost:8080";
+        EnvVar oauthEnvVar = new EnvVarBuilder()
+            .withName("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM")
+            .withValue("ARNOST")
+            .build();
 
         KafkaProducerConsumer kafkaProducerConsumer = new KafkaProducerConsumerBuilder()
             .withProducerName(producerName)
@@ -204,6 +208,7 @@ public class KafkaProducerConsumerTest {
                     .withOauthClientSecret(clientSecret)
                     .withOauthRefreshToken(refreshToken)
                     .withOauthTokenEndpointUri(endpointUri)
+                    .withAdditionalOAuthEnvVars(oauthEnvVar)
                 .endOauth()
             .endAuthentication()
             .build();
@@ -214,7 +219,7 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(9));
+        assertThat(envVars.size(), is(10));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
@@ -224,6 +229,7 @@ public class KafkaProducerConsumerTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
 
         // Consumer part
         job = kafkaProducerConsumer.getConsumer().getJob();
@@ -231,7 +237,7 @@ public class KafkaProducerConsumerTest {
         envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(9));
+        assertThat(envVars.size(), is(10));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
@@ -241,6 +247,7 @@ public class KafkaProducerConsumerTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
@@ -133,6 +133,10 @@ public class KafkaStreamsClientTest {
         String clientSecret = "client-secret";
         String refreshToken = "my-refresh-token";
         String endpointUri = "localhost:8080";
+        EnvVar oauthEnvVar = new EnvVarBuilder()
+            .withName("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM")
+            .withValue("ARNOST")
+            .build();
 
         KafkaStreamsClient kafkaStreamsClient = new KafkaStreamsClientBuilder()
             .withName(name)
@@ -148,6 +152,7 @@ public class KafkaStreamsClientTest {
                     .withOauthClientSecret(clientSecret)
                     .withOauthRefreshToken(refreshToken)
                     .withOauthTokenEndpointUri(endpointUri)
+                    .withAdditionalOAuthEnvVars(oauthEnvVar)
                 .endOauth()
             .endAuthentication()
             .build();
@@ -157,7 +162,7 @@ public class KafkaStreamsClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(10));
+        assertThat(envVars.size(), is(11));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaStreams.name()));
         assertThat(envVars.get(ConfigurationConstants.APPLICATION_ID_ENV), is(applicationId));
@@ -169,6 +174,7 @@ public class KafkaStreamsClientTest {
         assertThat(envVars.get(ConfigurationConstants.OAUTH_CLIENT_SECRET_ENV), is(clientSecret));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_REFRESH_TOKEN_ENV), is(refreshToken));
         assertThat(envVars.get(ConfigurationConstants.OAUTH_TOKEN_ENDPOINT_URI_ENV), is(endpointUri));
+        assertThat(envVars.get("OAUTH_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"), is("ARNOST"));
     }
 
     @Test


### PR DESCRIPTION
This PR adds possibility to specify additional OAuth env variables, which shouldn't be part of the builders, but for better handling we should have some possibility how to specify them - without need to use of additional env vars outside the `Authentication`.
This would help in case that we want to create some helper methods for authentication part and we want to just return `Authentication` object without updating whole Job (and have it a bit generic).