### PR TITLE
Add additional tracing env variables to builders

### DIFF
--- a/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/http/HttpProducerConsumer.java
@@ -97,6 +97,7 @@ public class HttpProducerConsumer extends HttpCommon {
                 .withTracingType(getTracing().getTracingType())
                 .withServiceNameEnvVar(getTracing().getServiceNameEnvVar())
                 .withServiceName(getTracing().getServiceName() + "-producer")
+                .withAdditionalTracingEnvVars(getTracing().getAdditionalTracingEnvVars())
                 .build();
         }
 
@@ -131,6 +132,7 @@ public class HttpProducerConsumer extends HttpCommon {
                 .withTracingType(getTracing().getTracingType())
                 .withServiceNameEnvVar(getTracing().getServiceNameEnvVar())
                 .withServiceName(getTracing().getServiceName() + "-consumer")
+                .withAdditionalTracingEnvVars(getTracing().getAdditionalTracingEnvVars())
                 .build();
         }
 

--- a/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
+++ b/builders/src/main/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumer.java
@@ -156,6 +156,7 @@ public class KafkaProducerConsumer extends KafkaCommon {
                 .withTracingType(getTracing().getTracingType())
                 .withServiceNameEnvVar(getTracing().getServiceNameEnvVar())
                 .withServiceName(getTracing().getServiceName() + "-producer")
+                .withAdditionalTracingEnvVars(getTracing().getAdditionalTracingEnvVars())
                 .build();
         }
 
@@ -192,6 +193,7 @@ public class KafkaProducerConsumer extends KafkaCommon {
                 .withTracingType(getTracing().getTracingType())
                 .withServiceNameEnvVar(getTracing().getServiceNameEnvVar())
                 .withServiceName(getTracing().getServiceName() + "-consumer")
+                .withAdditionalTracingEnvVars(getTracing().getAdditionalTracingEnvVars())
                 .build();
         }
 

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Tracing.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Tracing.java
@@ -16,6 +16,7 @@ public class Tracing {
     private String serviceName;
     private String serviceNameEnvVar;
     private String tracingType;
+    private List<EnvVar> additionalTracingEnvVars;
 
     public String getServiceName() {
         return serviceName;
@@ -41,6 +42,14 @@ public class Tracing {
         this.tracingType = tracingType;
     }
 
+    public List<EnvVar> getAdditionalTracingEnvVars() {
+        return additionalTracingEnvVars;
+    }
+
+    public void setAdditionalTracingEnvVars(List<EnvVar> additionalTracingEnvVars) {
+        this.additionalTracingEnvVars = additionalTracingEnvVars;
+    }
+
     public List<EnvVar> getTracingEnvVars() {
         List<EnvVar> envVars = new ArrayList<>();
 
@@ -54,6 +63,10 @@ public class Tracing {
         }
 
         Environment.configureEnvVariableOrSkip(envVars, ConfigurationConstants.TRACING_TYPE_ENV, this.getTracingType());
+
+        if (additionalTracingEnvVars != null && !additionalTracingEnvVars.isEmpty()) {
+            envVars.addAll(additionalTracingEnvVars);
+        }
 
         return envVars;
     }

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
@@ -115,6 +115,10 @@ public class HttpConsumerClientTest {
         String topicName = "my-topic";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
         String tracingType = "OpenTelemetry";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         HttpConsumerClient httpConsumerClient = new HttpConsumerClientBuilder()
             .withName(name)
@@ -128,6 +132,7 @@ public class HttpConsumerClientTest {
                 .withServiceNameEnvVar(serviceNameEnvVar)
                 .withServiceName(name)
                 .withTracingType(tracingType)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -137,6 +142,7 @@ public class HttpConsumerClientTest {
 
         assertThat(consumerEnvVars.get(serviceNameEnvVar), is(name));
         assertThat(consumerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
+        assertThat(consumerEnvVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
@@ -107,6 +107,10 @@ public class HttpProducerClientTest {
         String topicName = "my-topic";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
         String tracingType = "OpenTelemetry";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         HttpProducerClient httpProducerClient = new HttpProducerClientBuilder()
             .withName(name)
@@ -120,6 +124,7 @@ public class HttpProducerClientTest {
                 .withServiceNameEnvVar(serviceNameEnvVar)
                 .withServiceName(name)
                 .withTracingType(tracingType)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -129,6 +134,7 @@ public class HttpProducerClientTest {
 
         assertThat(producerEnvVars.get(serviceNameEnvVar), is(name));
         assertThat(producerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
+        assertThat(producerEnvVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
@@ -155,6 +155,10 @@ public class HttpProducerConsumerTest {
         String tracingServiceName = "tracing";
         String producerServiceName = tracingServiceName + "-producer";
         String consumerServiceName = tracingServiceName + "-consumer";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         HttpProducerConsumer httpProducerConsumer = new HttpProducerConsumerBuilder()
             .withProducerName(producerName)
@@ -167,6 +171,7 @@ public class HttpProducerConsumerTest {
                 .withServiceName(tracingServiceName)
                 .withServiceNameEnvVar(serviceNameEnvVar)
                 .withTracingType(tracingType)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -177,7 +182,7 @@ public class HttpProducerConsumerTest {
 
         assertThat(producerEnvVars.get(serviceNameEnvVar), is(producerServiceName));
         assertThat(producerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
-
+        assertThat(producerEnvVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
 
         // Consumer part
         Job httpConsumerJob = httpProducerConsumer.getConsumer().getJob();
@@ -186,6 +191,7 @@ public class HttpProducerConsumerTest {
 
         assertThat(consumerEnvVars.get(serviceNameEnvVar), is(consumerServiceName));
         assertThat(consumerEnvVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
+        assertThat(consumerEnvVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
@@ -275,6 +275,10 @@ public class KafkaConsumerClientTest {
 
         String tracingType = "OpenTelemetry";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         KafkaConsumerClient kafkaConsumerClient = new KafkaConsumerClientBuilder()
             .withName(name)
@@ -285,6 +289,7 @@ public class KafkaConsumerClientTest {
                 .withServiceName(name)
                 .withTracingType(tracingType)
                 .withServiceNameEnvVar(serviceNameEnvVar)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -293,13 +298,14 @@ public class KafkaConsumerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(5));
+        assertThat(envVars.size(), is(6));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
 
         assertThat(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
         assertThat(envVars.get(serviceNameEnvVar), is(name));
+        assertThat(envVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
@@ -286,6 +286,10 @@ public class KafkaProducerClientTest {
 
         String tracingType = "OpenTelemetry";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         KafkaProducerClient kafkaProducerClient = new KafkaProducerClientBuilder()
             .withName(name)
@@ -296,6 +300,7 @@ public class KafkaProducerClientTest {
                 .withServiceName(name)
                 .withTracingType(tracingType)
                 .withServiceNameEnvVar(serviceNameEnvVar)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -304,13 +309,14 @@ public class KafkaProducerClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(5));
+        assertThat(envVars.size(), is(6));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
 
         assertThat(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
         assertThat(envVars.get(serviceNameEnvVar), is(name));
+        assertThat(envVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
@@ -403,6 +403,10 @@ public class KafkaProducerConsumerTest {
         String tracingType = "OpenTelemetry";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
         String serviceName = "my-service";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         KafkaProducerConsumer kafkaProducerConsumer = new KafkaProducerConsumerBuilder()
             .withProducerName(producerName)
@@ -414,6 +418,7 @@ public class KafkaProducerConsumerTest {
                 .withServiceName(serviceName)
                 .withTracingType(tracingType)
                 .withServiceNameEnvVar(serviceNameEnvVar)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -423,13 +428,14 @@ public class KafkaProducerConsumerTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(7));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaProducer.name()));
 
         assertThat(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
         assertThat(envVars.get(serviceNameEnvVar), is(serviceName + "-producer"));
+        assertThat(envVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
 
         // Consumer part
         job = kafkaProducerConsumer.getConsumer().getJob();
@@ -437,13 +443,14 @@ public class KafkaProducerConsumerTest {
         envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(6));
+        assertThat(envVars.size(), is(7));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.TOPIC_ENV), is(topicName));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaConsumer.name()));
 
         assertThat(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
         assertThat(envVars.get(serviceNameEnvVar), is(serviceName + "-consumer"));
+        assertThat(envVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
@@ -293,6 +293,10 @@ public class KafkaStreamsClientTest {
 
         String tracingType = "OpenTelemetry";
         String serviceNameEnvVar = "OTEL_SERVICE_NAME";
+        EnvVar additionalTracingEnv = new EnvVarBuilder()
+            .withName("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .withValue("endpoint")
+            .build();
 
         KafkaStreamsClient kafkaStreamsClient = new KafkaStreamsClientBuilder()
             .withName(name)
@@ -305,6 +309,7 @@ public class KafkaStreamsClientTest {
                 .withServiceName(name)
                 .withTracingType(tracingType)
                 .withServiceNameEnvVar(serviceNameEnvVar)
+                .withAdditionalTracingEnvVars(additionalTracingEnv)
             .endTracing()
             .build();
 
@@ -313,7 +318,7 @@ public class KafkaStreamsClientTest {
         Map<String, String> envVars = container.getEnv().stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
 
         // this will ensure that no other env variables are set, only those we are setting
-        assertThat(envVars.size(), is(7));
+        assertThat(envVars.size(), is(8));
         assertThat(envVars.get(ConfigurationConstants.BOOTSTRAP_SERVERS_ENV), is(bootstrapAddress));
         assertThat(envVars.get(ConfigurationConstants.CLIENT_TYPE_ENV), is(ClientType.KafkaStreams.name()));
         assertThat(envVars.get(ConfigurationConstants.APPLICATION_ID_ENV), is(applicationId));
@@ -322,6 +327,7 @@ public class KafkaStreamsClientTest {
 
         assertThat(envVars.get(ConfigurationConstants.TRACING_TYPE_ENV), is(tracingType));
         assertThat(envVars.get(serviceNameEnvVar), is(name));
+        assertThat(envVars.get("OTEL_EXPORTER_OTLP_ENDPOINT"), is("endpoint"));
     }
 
     @Test


### PR DESCRIPTION
This PR - similarly to the PR related to OAuth - adds possibility to specify additional env variables for tracing - so users can specify whatever else env variables they need in clients deployment - in our case it is for example `OTEL_EXPORTER_OTLP_ENDPOINT`.