### PR TITLE
Add environment variable for configuring default image in builders

### DIFF
--- a/builders/src/main/java/io/strimzi/testclients/configuration/Environment.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Environment.java
@@ -56,4 +56,18 @@ public class Environment {
             );
         }
     }
+
+    /**
+     * Method for returning value of the environment variable, or default in case that the env value is empty or null.
+     *
+     * @param envVariable   Name of the environment variable from which the value should be taken.
+     * @param defaultValue  Default value if value in enviroment variable is empty.
+     *
+     * @return  value of the environment variable, or default in case that the env value is empty or null.
+     */
+    public static String getEnvOrDefault(String envVariable, String defaultValue) {
+        String envValue = System.getenv(envVariable);
+
+        return envValue == null || envValue.isEmpty() ? defaultValue : envValue;
+    }
 }

--- a/builders/src/main/java/io/strimzi/testclients/configuration/Image.java
+++ b/builders/src/main/java/io/strimzi/testclients/configuration/Image.java
@@ -8,8 +8,10 @@ import io.sundr.builder.annotations.Buildable;
 
 @Buildable(editableEnabled = false)
 public class Image {
-    public static String defaultImage = "quay.io/strimzi-test-clients/test-clients:latest-kafka-4.2.0";
-    private String imageName = defaultImage;
+    public static final String STRIMZI_TEST_CLIENTS_DEFAULT_IMAGE_ENV = "STRIMZI_TEST_CLIENTS_DEFAULT_IMAGE";
+    public static final String TEST_CLIENTS_DEFAULT_IMAGE = "quay.io/strimzi-test-clients/test-clients:latest-kafka-4.2.0";
+
+    private String imageName = Environment.getEnvOrDefault(STRIMZI_TEST_CLIENTS_DEFAULT_IMAGE_ENV, TEST_CLIENTS_DEFAULT_IMAGE);
     private String imagePullPolicy = "IfNotPresent";
     private String imagePullSecret;
 

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpConsumerClientTest.java
@@ -81,7 +81,7 @@ public class HttpConsumerClientTest {
         assertThat(httpConsumerJob.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
         assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerClientTest.java
@@ -77,7 +77,7 @@ public class HttpProducerClientTest {
         assertThat(httpProducerJob.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
         assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));

--- a/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/http/HttpProducerConsumerTest.java
@@ -86,7 +86,7 @@ public class HttpProducerConsumerTest {
         assertThat(httpProducerJob.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(producerName));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
         assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));
@@ -119,7 +119,7 @@ public class HttpProducerConsumerTest {
         assertThat(httpConsumerJob.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(consumerName));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         assertThat(envVars.get(ConfigurationConstants.HOSTNAME_ENV), is(hostName));
         assertThat(envVars.get(ConfigurationConstants.PORT_ENV), is(String.valueOf(port)));

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaAdminClientTest.java
@@ -60,7 +60,7 @@ public class KafkaAdminClientTest {
         assertThat(deployment.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(5));

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaConsumerClientTest.java
@@ -71,7 +71,7 @@ public class KafkaConsumerClientTest {
         assertThat(job.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(11));

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerClientTest.java
@@ -78,7 +78,7 @@ public class KafkaProducerClientTest {
         assertThat(job.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(14));

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaProducerConsumerTest.java
@@ -87,7 +87,7 @@ public class KafkaProducerConsumerTest {
         assertThat(job.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(producerName));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(13));
@@ -116,7 +116,7 @@ public class KafkaProducerConsumerTest {
         assertThat(job.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(consumerName));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(11));

--- a/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
+++ b/builders/src/test/java/io/strimzi/testclients/clients/kafka/KafkaStreamsClientTest.java
@@ -67,7 +67,7 @@ public class KafkaStreamsClientTest {
         assertThat(job.getMetadata().getNamespace(), is(namespaceName));
 
         assertThat(container.getName(), is(name));
-        assertThat(container.getImage(), is(Image.defaultImage));
+        assertThat(container.getImage(), is(Image.TEST_CLIENTS_DEFAULT_IMAGE));
 
         // this will ensure that no other env variables are set, only those we are setting
         assertThat(envVars.size(), is(9));


### PR DESCRIPTION
This PR adds possibility to specify env variable to configure the default image used in the builders.
It would make work with the builders easier - in case that we want to use different image for all tests, we don't need to handle the `Image` field in every case, we need to just configure the env variable.

Fixes #174